### PR TITLE
updated internals of arg def handling + reworked c.item and c.attr to…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,24 @@
-0.22.0 (2022-??-??)
+0.22.0 (2022-01-02)
 ___________________
+
+`#16 <https://github.com/westandskif/convtools/pull/16>`_
+
+Features
+++++++++
+
+- added ``c.ReduceFuncs.ArraySorted`` reducer
+- reworked ``GetItem`` and ``GetAttr`` to cache ``get_or_default`` methods
+  based on number of indexes and args
+- added support for single column tables (headers are always str still)
 
 Misc
 ++++
 
 - updated internals of arg def handling, made naive and labels optional
-- added ``c.ReduceFuncs.ArraySorted`` reducer
 - removed ``NamedConversion`` and ``ConversionWrapper`` in favor of new
   ``LazyEscapedString``, ``Namespace`` and ``NamespaceCtx``. This lays better
   groundwork for future use of conversions which generate code around another
   named ones.
-- reworked ``GetItem`` and ``GetAttr`` to cache ``get_or_default`` methods
-  based on number of indexes and args
-- added support of rows as list of strings
-  TODO: list of any non-lists/non-tuples
 
 0.21.0 (2021-12-19)
 ___________________

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,20 @@
+0.22.0 (2022-??-??)
+___________________
+
+Misc
+++++
+
+- updated internals of arg def handling, made naive and labels optional
+- added ``c.ReduceFuncs.ArraySorted`` reducer
+- removed ``NamedConversion`` and ``ConversionWrapper`` in favor of new
+  ``LazyEscapedString``, ``Namespace`` and ``NamespaceCtx``. This lays better
+  groundwork for future use of conversions which generate code around another
+  named ones.
+- reworked ``GetItem`` and ``GetAttr`` to cache ``get_or_default`` methods
+  based on number of indexes and args
+- added support of rows as list of strings
+  TODO: list of any non-lists/non-tuples
+
 0.21.0 (2021-12-19)
 ___________________
 

--- a/README.rst
+++ b/README.rst
@@ -258,12 +258,13 @@ ones, exposed like ``c.ReduceFuncs.Sum``:
 #. Last
 #. Average
 #. Median
-#. Percentile
+#. Percentile - ``c.ReduceFuncs.Percentile(95.0, c.item("x"))``
 #. Mode
-#. TopK
+#. TopK - ``c.ReduceFuncs.TopK(3, c.item("x"))``
 #. Array
 #. ArrayDistinct
-#. Dict
+#. ArraySorted - ``c.ReduceFuncs.ArraySorted(c.item("x"), key=lambda v: v, reverse=True)``
+#. Dict - ``c.ReduceFuncs.Dict(c.item("key"), c.item("x"))``
 #. DictArray
 #. DictSum
 #. DictSumOrNone

--- a/docs/base_index.rst
+++ b/docs/base_index.rst
@@ -120,12 +120,13 @@ ones, exposed like ``c.ReduceFuncs.Sum``:
 #. Last
 #. Average
 #. Median
-#. Percentile
+#. Percentile - ``c.ReduceFuncs.Percentile(95.0, c.item("x"))``
 #. Mode
-#. TopK
+#. TopK - ``c.ReduceFuncs.TopK(3, c.item("x"))``
 #. Array
 #. ArrayDistinct
-#. Dict
+#. ArraySorted - ``c.ReduceFuncs.ArraySorted(c.item("x"), key=lambda v: v, reverse=True)``
+#. Dict - ``c.ReduceFuncs.Dict(c.item("key"), c.item("x"))``
 #. DictArray
 #. DictSum
 #. DictSumOrNone

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -686,6 +686,7 @@ _____________________
 * TopK - ``c.ReduceFuncs.TopK(3, c.item("x"))``
 * Array
 * ArrayDistinct
+* ArraySorted - ``c.ReduceFuncs.ArraySorted(c.item("x"), key=lambda v: v, reverse=True)``
 * Dict - ``c.ReduceFuncs.Dict(c.item("key"), c.item("x"))``
 * DictArray
 * DictSum

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = convtools
-version = 0.21.0
+version = 0.22.0
 description = convtools allows to define and reuse conversions for processing collections and csv tables, complex aggregations and joins.
 author = Nikita Almakov
 author_email = nikita.almakov@gmail.com

--- a/src/convtools/__init__.py
+++ b/src/convtools/__init__.py
@@ -3,4 +3,4 @@ This object exposes the public API of conversions."""
 from .conversion import conversion  # noqa: F401
 
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/src/convtools/aggregations.py
+++ b/src/convtools/aggregations.py
@@ -1018,7 +1018,8 @@ class ListSortedOnceWrapper:
 
 
 class SortedArrayReducer(MultiStatementReducer):
-    # preserve this extra line to keep this different from ArrayReducer
+    """Array reducer which sorts the list just once in the end"""
+
     reduce = ("%(result)s.append({0})",)
     default = NaiveConversion(None)
     unconditional_init = True

--- a/src/convtools/aggregations.py
+++ b/src/convtools/aggregations.py
@@ -16,6 +16,7 @@ from .base import (
     InlineExpr,
     List,
     NaiveConversion,
+    This,
     Tuple,
     _None,
     ensure_conversion,
@@ -148,7 +149,11 @@ class ReduceBlocks(typing.Generic[RBT]):
         yield from self.conditional_init_blocks.values()
 
     def gen_group_by_code(
-        self, var_row, var_agg_data, var_signature_to_agg_data, code_signature
+        self,
+        var_row,
+        var_agg_data,
+        var_signature_to_agg_data,
+        code_signature,
     ) -> Code:
         code = Code()
         code.add_line(f"for {var_row} in data_:", 1)
@@ -181,7 +186,10 @@ class ReduceBlocks(typing.Generic[RBT]):
         return code
 
     def gen_aggregate_code(
-        self, var_row, var_checksum, var_expected_checksum
+        self,
+        var_row,
+        var_checksum,
+        var_expected_checksum,
     ) -> Code:
         first_phase_code = Code()
         second_phase_code = Code()
@@ -255,8 +263,10 @@ class ReduceBlocks(typing.Generic[RBT]):
                     second_phase_code.incr_indent_level(-1)
 
         resulting_code = Code()
+
         resulting_code.add_line("it_ = iter(data_)", 0)
         resulting_code.add_line(f"for {var_row} in it_:", 1)
+
         resulting_code.add_code(first_phase_code)
         if needs_sum_checking:
             resulting_code.add_line(
@@ -267,6 +277,7 @@ class ReduceBlocks(typing.Generic[RBT]):
         if second_phase_code.has_lines():
             resulting_code.add_line("", 0)
             resulting_code.add_line(f"for {var_row} in it_:", 1)
+
             resulting_code.add_code(second_phase_code)
             resulting_code.incr_indent_level(-1)
         return resulting_code
@@ -310,6 +321,10 @@ class BaseReducer(BaseConversion, typing.Generic[RBT]):
         BaseConversion.self_content_type | BaseConversion.ContentTypes.REDUCER
     )
 
+    def __init__(self):
+        super().__init__()
+        self.ensure_conversion(self.post_conversion)
+
     def gen_reduce_code_block(
         self,
         var_agg_data_value: str,
@@ -337,6 +352,7 @@ class BaseReducer(BaseConversion, typing.Generic[RBT]):
             )
 
         processed_agg_data_item = agg_data_item
+
         if self.post_conversion:
             processed_agg_data_item = (
                 self.post_conversion.gen_code_and_update_ctx(
@@ -425,14 +441,18 @@ class MultiStatementReducer(BaseReducer):
     ) -> RBT:
         if self.initial is _none:
             reduce_initial = self._format_statements(
-                self.prepare_first,
+                (
+                    self.prepare_first(ctx)
+                    if callable(self.prepare_first)
+                    else self.prepare_first
+                ),
                 self.expressions,
                 var_row,
                 ctx,
             )
         else:
             reduce_initial = self._format_statements(
-                self.reduce,
+                (self.reduce(ctx) if callable(self.reduce) else self.reduce),
                 self.expressions,
                 var_row,
                 ctx,
@@ -440,7 +460,7 @@ class MultiStatementReducer(BaseReducer):
             )
 
         reduce_two = self._format_statements(
-            self.reduce,
+            (self.reduce(ctx) if callable(self.reduce) else self.reduce),
             self.expressions,
             var_row,
             ctx,
@@ -594,7 +614,8 @@ class GroupBy(BaseConversion, typing.Generic[RBT]):
         aggregation"""
         self_clone = self.clone()
         self_clone.agg_result = self_clone.ensure_conversion(reducer)
-        self_clone.contents = self_clone.contents & ~self.ContentTypes.REDUCER
+        self_clone.contents = self_clone.contents ^ self.ContentTypes.REDUCER
+
         if isinstance(self_clone.agg_result, NaiveConversion):
             raise AssertionError("unexpected reducer type", type(reducer))
         return self_clone
@@ -639,200 +660,212 @@ class GroupBy(BaseConversion, typing.Generic[RBT]):
         var_agg_data = f"agg_data{suffix}"
         var_agg_data_cls = f"AggData{suffix}"
 
-        signature_code_items = [
-            by_.gen_code_and_update_ctx(var_row, ctx) for by_ in self.by
-        ]
-        replacements = {}
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
 
-        # remembering code replacements for group by keys
-        if len(signature_code_items) == 1:
-            code_signature = signature_code_items[0]
-            replacements[code_signature] = var_signature
-        else:
-            code_signature = f"({','.join(signature_code_items)},)"
-            replacements.update(
-                {
-                    code: f"{var_signature}[{index}]"
-                    for index, (code, by_) in enumerate(
-                        zip(signature_code_items, self.by)
+        with namespace_ctx:
+
+            signature_code_items = [
+                by_.gen_code_and_update_ctx(var_row, ctx) for by_ in self.by
+            ]
+            replacements = {}
+
+            # remembering code replacements for group by keys
+            if len(signature_code_items) == 1:
+                code_signature = signature_code_items[0]
+                replacements[code_signature] = var_signature
+            else:
+                code_signature = f"({','.join(signature_code_items)},)"
+                replacements.update(
+                    {
+                        code: f"{var_signature}[{index}]"
+                        for index, (code, by_) in enumerate(
+                            zip(signature_code_items, self.by)
+                        )
+                    }
+                )
+
+            # collecting inputs of reducers and reducers themselves
+            with CodeGenerationOptionsCtx() as options:
+                options.reducers_run_stage = "collecting_reducer_inputs"
+                key = "_reducer_inputs_info"
+                if key not in ctx:
+                    ctx[key] = []
+                ctx[key].append(defaultdict(list))
+                self.agg_result.gen_code_and_update_ctx(var_row, ctx)
+                reducer_inputs_info = ctx[key].pop()
+
+            def gen_agg_data_value(value_index):
+                if aggregate_mode:
+                    return EscapedString(
+                        f"{var_agg_data}_v{value_index}"
+                    ).gen_code_and_update_ctx("", ctx)
+                else:
+                    return (
+                        EscapedString(var_agg_data)
+                        .attr(f"v{value_index}")
+                        .gen_code_and_update_ctx("", ctx)
                     )
-                }
-            )
 
-        # collecting inputs of reducers and reducers themselves
-        with CodeGenerationOptionsCtx() as options:
-            options.reducers_run_stage = "collecting_reducer_inputs"
-            key = "_reducer_inputs_info"
-            if key not in ctx:
-                ctx[key] = []
-            ctx[key].append(defaultdict(list))
-            self.agg_result.gen_code_and_update_ctx(var_row, ctx)
-            reducer_inputs_info = ctx[key].pop()
+            expected_checksum = 0
+            var_agg_data_values = []
 
-        def gen_agg_data_value(value_index):
-            if aggregate_mode:
-                return EscapedString(
-                    f"{var_agg_data}_v{value_index}"
-                ).gen_code_and_update_ctx("", ctx)
-            else:
-                return (
-                    EscapedString(var_agg_data)
-                    .attr(f"v{value_index}")
-                    .gen_code_and_update_ctx("", ctx)
-                )
-
-        expected_checksum = 0
-        var_agg_data_values = []
-
-        blocks: typing.List[RBT] = []
-        overwritten_reducer_inputs = {}
-        # reusing same reducers, remembering code replacements for reducers
-        for reducer_code_input, reducer in (
-            (reducer_code_input, reducer)
-            for reducer_code_input, reducers in reducer_inputs_info.items()
-            for reducer in reducers
-        ):
-            reduce_block_index = len(blocks)
-            checksum_flag = (
-                1 << reduce_block_index if self.aggregate_mode else 0
-            )
-            var_agg_data_value = gen_agg_data_value(reduce_block_index)
-            reduce_block = reducer.gen_reduce_code_block(
-                var_agg_data_value,
-                reducer_code_input,
-                checksum_flag,
-                ctx,
-            )
-
-            such_block_exists = False
-            for index, block in enumerate(blocks):
-                if reduce_block.same_as(block):
-                    reduce_block_index = index
-                    such_block_exists = True
-                    break
-
-            if not such_block_exists:
-                blocks.append(reduce_block)
-                var_agg_data_values.append(var_agg_data_value)
-                expected_checksum |= checksum_flag
-
-            overwritten_reducer_inputs[
+            blocks: typing.List[RBT] = []
+            overwritten_reducer_inputs = {}
+            # reusing same reducers, remembering code replacements for reducers
+            for reducer_code_input, reducer in (
                 (reducer_code_input, reducer)
-            ] = gen_agg_data_value(reduce_block_index)
+                for reducer_code_input, reducers in reducer_inputs_info.items()
+                for reducer in reducers
+            ):
+                reduce_block_index = len(blocks)
+                checksum_flag = (
+                    1 << reduce_block_index if self.aggregate_mode else 0
+                )
+                var_agg_data_value = gen_agg_data_value(reduce_block_index)
+                reduce_block = reducer.gen_reduce_code_block(
+                    var_agg_data_value,
+                    reducer_code_input,
+                    checksum_flag,
+                    ctx,
+                )
 
-        reduce_blocks: ReduceBlocks = ReduceBlocks()
-        for block in blocks:
-            reduce_blocks.add_block(block)
+                such_block_exists = False
+                for index, block in enumerate(blocks):
+                    if reduce_block.same_as(block):
+                        reduce_block_index = index
+                        such_block_exists = True
+                        break
 
-        # populates reducers with their code inputs
-        with CodeGenerationOptionsCtx() as options:
-            options.reducers_run_stage = "rendering_reducer_results"
-            key = "_overwritten_reducer_inputs"
-            if key not in ctx:
-                ctx[key] = []
-            ctx[key].append(overwritten_reducer_inputs)
-            code_agg_result = self.agg_result.gen_code_and_update_ctx(
-                var_row, ctx
+                if not such_block_exists:
+                    blocks.append(reduce_block)
+                    var_agg_data_values.append(var_agg_data_value)
+                    expected_checksum |= checksum_flag
+
+                overwritten_reducer_inputs[
+                    (reducer_code_input, reducer)
+                ] = gen_agg_data_value(reduce_block_index)
+
+            reduce_blocks: ReduceBlocks = ReduceBlocks()
+            for block in blocks:
+                reduce_blocks.add_block(block)
+
+            # populates reducers with their code inputs
+            with CodeGenerationOptionsCtx() as options:
+                options.reducers_run_stage = "rendering_reducer_results"
+                key = "_overwritten_reducer_inputs"
+                if key not in ctx:
+                    ctx[key] = []
+                ctx[key].append(overwritten_reducer_inputs)
+                code_agg_result = self.agg_result.gen_code_and_update_ctx(
+                    var_row, ctx
+                )
+                ctx[key].pop()
+
+            ctx.update({"defaultdict": defaultdict})
+
+            if aggregate_mode:
+                _ = " = ".join(var_agg_data_values)
+                code_init_agg_vars = f"{_} = _none"
+            else:
+                ctx[var_agg_data_cls] = self._gen_agg_data_container(
+                    var_agg_data_cls, reduce_blocks.number, ctx
+                )
+
+            # used by SortedArrayReducer
+            ctx["ListSortedOnceWrapper"] = ListSortedOnceWrapper
+
+            for code_from, code_to in replacements.items():
+                code_agg_result = self.replace_word(
+                    code_agg_result, code_from, code_to
+                )
+
+            if self.count_words(code_agg_result, var_row):
+                raise ConversionException(
+                    "something other than a group by key or a reducer was used",
+                    code_agg_result,
+                )
+            if self.aggregate_mode:
+                code_agg_result = f"    return {code_agg_result}"
+            else:
+                if self.filter_conversion is None:
+                    code_agg_result = (
+                        f"    return [{code_agg_result} "
+                        f"for {var_signature}, {var_agg_data} "
+                        f"in {var_signature_to_agg_data}.items()]"
+                    )
+                else:
+                    code_filtered_result = FilterConversion(
+                        self.filter_conversion,
+                        self.filter_cast,
+                    ).gen_code_and_update_ctx("result_", ctx)
+                    code_agg_result = (
+                        f"    result_ = ({code_agg_result} "
+                        f"for {var_signature}, {var_agg_data} "
+                        f"in {var_signature_to_agg_data}.items())\n"
+                        f"    filtered_result_ = {code_filtered_result}\n"
+                    ) + (
+                        "    yield from filtered_result_"
+                        if self.filter_cast is None
+                        else "    return filtered_result_"
+                    )
+
+            agg_template_kwargs = dict(
+                code_args=code_args,
+                code_result=code_agg_result,
+                var_row=var_row,
+                expected_checksum=expected_checksum,
             )
-            ctx[key].pop()
 
-        ctx.update({"defaultdict": defaultdict})
-
-        if aggregate_mode:
-            _ = " = ".join(var_agg_data_values)
-            code_init_agg_vars = f"{_} = _none"
-        else:
-            ctx[var_agg_data_cls] = self._gen_agg_data_container(
-                var_agg_data_cls, reduce_blocks.number, ctx
-            )
-
-        # used by SortedArrayReducer
-        ctx["ListSortedOnceWrapper"] = ListSortedOnceWrapper
-
-        for code_from, code_to in replacements.items():
-            code_agg_result = self.replace_word(
-                code_agg_result, code_from, code_to
-            )
-
-        if self.count_words(code_agg_result, var_row):
-            raise ConversionException(
-                "neither group by key nor a field used in a reducer",
-                code_agg_result,
-            )
-        if self.aggregate_mode:
-            code_agg_result = f"    return {code_agg_result}"
-        else:
-            if self.filter_conversion is None:
-                code_agg_result = (
-                    f"    return [{code_agg_result} "
-                    f"for {var_signature}, {var_agg_data} "
-                    f"in {var_signature_to_agg_data}.items()]"
+            if self.aggregate_mode:
+                converter_name = f"aggregate{suffix}"
+                grouper_code = AGGREGATE_TEMPLATE.format(
+                    converter_name=converter_name,
+                    code_init_agg_vars=code_init_agg_vars,
+                    var_expected_checksum=ReduceBlock.var_expected_checksum,
+                    val_expected_checksum=expected_checksum,
+                    var_checksum=ReduceBlock.var_checksum,
+                    code_aggregate=reduce_blocks.gen_aggregate_code(
+                        var_row=var_row,
+                        var_checksum=ReduceBlock.var_checksum,
+                        var_expected_checksum=expected_checksum,
+                    ).to_string(
+                        base_indent_level=1,
+                    ),
+                    **agg_template_kwargs,
                 )
             else:
-                code_filtered_result = FilterConversion(
-                    self.filter_conversion,
-                    self.filter_cast,
-                ).gen_code_and_update_ctx("result_", ctx)
-                code_agg_result = (
-                    f"    result_ = ({code_agg_result} "
-                    f"for {var_signature}, {var_agg_data} "
-                    f"in {var_signature_to_agg_data}.items())\n"
-                    f"    filtered_result_ = {code_filtered_result}\n"
-                ) + (
-                    "    yield from filtered_result_"
-                    if self.filter_cast is None
-                    else "    return filtered_result_"
+                converter_name = f"group_by{suffix}"
+                grouper_code = GROUPER_TEMPLATE.format(
+                    converter_name=converter_name,
+                    var_signature_to_agg_data=var_signature_to_agg_data,
+                    var_agg_data_cls=var_agg_data_cls,
+                    var_agg_data=var_agg_data,
+                    code_signature=code_signature,
+                    code_group_by=reduce_blocks.gen_group_by_code(
+                        var_row=var_row,
+                        var_agg_data=var_agg_data,
+                        var_signature_to_agg_data=var_signature_to_agg_data,
+                        code_signature=code_signature,
+                    ).to_string(base_indent_level=1),
+                    **agg_template_kwargs,
                 )
 
-        agg_template_kwargs = dict(
-            code_args=self.get_args_def_code(as_kwargs=False),
-            code_result=code_agg_result,
-            var_row=var_row,
-            expected_checksum=expected_checksum,
-        )
-
-        if self.aggregate_mode:
-            converter_name = f"aggregate{suffix}"
-            grouper_code = AGGREGATE_TEMPLATE.format(
+            self._code_to_converter(
                 converter_name=converter_name,
-                code_init_agg_vars=code_init_agg_vars,
-                var_expected_checksum=ReduceBlock.var_expected_checksum,
-                val_expected_checksum=expected_checksum,
-                var_checksum=ReduceBlock.var_checksum,
-                code_aggregate=reduce_blocks.gen_aggregate_code(
-                    var_row=var_row,
-                    var_checksum=ReduceBlock.var_checksum,
-                    var_expected_checksum=expected_checksum,
-                ).to_string(
-                    base_indent_level=1,
-                ),
-                **agg_template_kwargs,
+                code=grouper_code,
+                ctx=ctx,
             )
-        else:
-            converter_name = f"group_by{suffix}"
-            grouper_code = GROUPER_TEMPLATE.format(
-                converter_name=converter_name,
-                var_signature_to_agg_data=var_signature_to_agg_data,
-                var_agg_data_cls=var_agg_data_cls,
-                var_agg_data=var_agg_data,
-                code_signature=code_signature,
-                code_group_by=reduce_blocks.gen_group_by_code(
-                    var_row=var_row,
-                    var_agg_data=var_agg_data,
-                    var_signature_to_agg_data=var_signature_to_agg_data,
-                    code_signature=code_signature,
-                ).to_string(base_indent_level=1),
-                **agg_template_kwargs,
+            resulting_conversion = EscapedString(converter_name).call(
+                This(),
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
             )
-
-        group_data_func = self._code_to_converter(
-            converter_name=converter_name,
-            code=grouper_code,
-            ctx=ctx,
-        )
-        return CallFunc(
-            group_data_func, GetItem(), *self.get_args_as_func_args()
-        ).gen_code_and_update_ctx(code_input, ctx)
+        return resulting_conversion.gen_code_and_update_ctx(code_input, ctx)
 
 
 def Aggregate(  # pylint:disable=invalid-name
@@ -967,16 +1000,18 @@ class ListSortedOnceWrapper:
     """Wraps a list, exposes append method only. Once the list is filled up, it
     is sorted (only once) in-place and is returned when get method called."""
 
-    __slots__ = ["list_", "append", "sorted"]
+    __slots__ = ["list_", "append", "sorted", "key", "reverse"]
 
-    def __init__(self, list_: list):
+    def __init__(self, list_: list, key=None, reverse=False):
         self.list_ = list_
         self.append = self.list_.append
         self.sorted = False
+        self.key = key
+        self.reverse = reverse
 
     def get(self) -> list:
         if not self.sorted:
-            self.list_.sort()
+            self.list_.sort(key=self.key, reverse=self.reverse)
             self.sorted = True
             del self.append
         return self.list_
@@ -984,10 +1019,22 @@ class ListSortedOnceWrapper:
 
 class SortedArrayReducer(MultiStatementReducer):
     # preserve this extra line to keep this different from ArrayReducer
-    prepare_first = ("%(result)s = ListSortedOnceWrapper([{0}])", "")
     reduce = ("%(result)s.append({0})",)
     default = NaiveConversion(None)
     unconditional_init = True
+
+    def __init__(self, *args, key=None, reverse=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.key = self.ensure_conversion(key)
+        self.reverse = self.ensure_conversion(reverse)
+
+    def prepare_first(self, ctx):
+        key_code = self.key.gen_code_and_update_ctx("{0}", ctx)
+        reverse_code = self.reverse.gen_code_and_update_ctx("{0}", ctx)
+        return (
+            "%(result)s = ListSortedOnceWrapper("
+            f"[{{0}}], {key_code}, {reverse_code})",
+        )
 
     @property
     def post_conversion(self):
@@ -1189,7 +1236,6 @@ class TopReducer(DictCountReducer):
     """
 
     def __init__(self, k: int, key_conv, *args, **kwargs):
-        super().__init__(key_conv, 1, *args, **kwargs)
         if not isinstance(k, int):
             raise TypeError("K must be an integer.")
 
@@ -1197,6 +1243,7 @@ class TopReducer(DictCountReducer):
             raise ValueError("K must be a positive integer greater than 0.")
 
         self.k = k
+        super().__init__(key_conv, 1, *args, **kwargs)
 
     @property
     def post_conversion(self):
@@ -1243,17 +1290,18 @@ class PercentileReducer(SortedArrayReducer):
            #. "midpoint"
            #. "nearest"
         """
-        super().__init__(conv, *args, **kwargs)
-        if not 0 <= percentile <= 100:
-            raise ValueError(
-                "percentile must be a float between 0 and 100 inclusive"
-            )
 
         self.percentile = percentile
         try:
             self.method = self.interpolation_to_method[interpolation]
         except KeyError as e:
             raise ValueError("unsupported interpolation type") from e
+
+        super().__init__(conv, *args, **kwargs)
+        if not 0 <= percentile <= 100:
+            raise ValueError(
+                "percentile must be a float between 0 and 100 inclusive"
+            )
 
     @staticmethod
     def percentile_linear(data, quantile):
@@ -1364,6 +1412,8 @@ class ReduceFuncs:
     Array = ArrayReducer
     #: Aggregates distinct values into array, preserves order
     ArrayDistinct = ArrayDistinctReducer
+    #: Aggregates values into array, sorting them in the end
+    ArraySorted = SortedArrayReducer
 
     #: Aggregates values into dict; dict values are last values per group
     Dict = DictReducer

--- a/src/convtools/base.py
+++ b/src/convtools/base.py
@@ -175,7 +175,7 @@ def {converter_name}({code_args}):
     try:
         return {get_or_default_code}
     except (TypeError, KeyError, IndexError, AttributeError):
-        return default_
+        return {default_code}
 """
 
 
@@ -275,6 +275,7 @@ class BaseConversion(typing.Generic[CT]):
         LABEL_USAGE = 16
         BREAKPOINT = 32
         FUNCTION_OF_INPUT = 64
+        NAIVE_USAGE = 128
 
     self_content_type = ContentTypes.FUNCTION_OF_INPUT
 
@@ -390,52 +391,101 @@ class BaseConversion(typing.Generic[CT]):
             where,
         )
 
-    def get_args(self):
-        return sorted(
-            {
-                dep.arg_name: dep
-                for dep in self.get_dependencies(types=InputArg)
-            }.values(),
-            key=lambda k: k.arg_name,
-        )
-
-    def get_args_def_code(
+    def get_args_def_info(
         self,
+        ctx,
         as_kwargs=False,
+        args_to_skip=None,
         for_top_level_converter=False,
     ):
-        """Generates the code to define a function signature based on InputArgs
-        used inside the conversion"""
-        args = self.get_args()
-        if for_top_level_converter:
-            args = [arg for arg in args if arg.arg_name not in ("self", "cls")]
-
-        if args:
-            code = ", ".join(arg.arg_name for arg in args)
-            if as_kwargs:
-                code = f", *, {code}"
-            else:
-                code = f", {code}"
-        else:
-            code = ""
-        if not for_top_level_converter:
-            code = f", _naive, _labels, _none{code}"
-        return code
-
-    def get_args_as_func_args(self):
-        """Generates the code to pass InputArgs as arguments to the function"""
-        args = self.get_args()
-        ctx = {}
-        func_args = [
-            EscapedString("_naive"),
-            EscapedString("_labels"),
-            EscapedString("_none"),
-        ]
-        for arg in args:
-            func_args.append(
-                EscapedString(arg.gen_code_and_update_ctx(None, ctx))
+        args_to_skip = args_to_skip or set()
+        args = {
+            (dep.name, is_lazy): dep
+            for dep, is_lazy in (
+                (dep, isinstance(dep, LazyEscapedString))
+                for dep in self.get_dependencies()
             )
-        return func_args
+            if isinstance(dep, InputArg)
+            and dep.name not in args_to_skip
+            or is_lazy
+        }
+        if for_top_level_converter:
+            non_resolved_lazy = [
+                dep_name for dep_name, is_lazy in args if is_lazy
+            ]
+            if non_resolved_lazy:
+                raise ValueError(
+                    "non-resolved lazy escaped strings", non_resolved_lazy
+                )
+
+        if len({dep_name for dep_name, _ in args}) != len(args):
+            raise ValueError("duplicate args found", args)
+
+        name_to_code = {}
+
+        positional_args_as_def_names = []
+        positional_args_as_conversions = []
+        keyword_args_as_def_names = []
+        keyword_args_as_conversions = {}
+
+        if "_none" not in args_to_skip:
+            positional_args_as_def_names.append("_none")
+            positional_args_as_conversions.append(EscapedString("_none"))
+
+        if "_naive" not in args_to_skip and (
+            self.contents & self.ContentTypes.NAIVE_USAGE
+        ):
+            positional_args_as_def_names.append("_naive")
+            positional_args_as_conversions.append(EscapedString("_naive"))
+
+        if "_labels" not in args_to_skip and self.contents & (
+            self.ContentTypes.LABEL_USAGE | self.ContentTypes.NEW_LABEL
+        ):
+            positional_args_as_def_names.append("_labels")
+            positional_args_as_conversions.append(EscapedString("_labels"))
+
+        suffix = None
+        for key, dep in args.items():
+            dep_name, is_named_conversion = key
+            if is_named_conversion:
+                suffix = suffix or self.gen_name("_", ctx, self)
+                def_name = f"{dep.name}{suffix}"
+                name_to_code[dep.name] = def_name
+            else:
+                def_name = dep_name
+
+            if as_kwargs:
+                keyword_args_as_def_names.append(def_name)
+                keyword_args_as_conversions[def_name] = dep
+            else:
+                positional_args_as_def_names.append(def_name)
+                positional_args_as_conversions.append(dep)
+
+        code_args = ", "
+
+        if positional_args_as_def_names:
+            code_args = f"{code_args}{', '.join(positional_args_as_def_names)}"
+
+        if keyword_args_as_def_names:
+            code_args = (
+                f"{code_args} *, {', '.join(keyword_args_as_def_names)}"
+            )
+
+        namespace_ctx = NamespaceCtx(name_to_code, ctx)
+        positional_args_as_conversions = [
+            namespace_ctx.prevent_rendering_while_active(conv)
+            for conv in positional_args_as_conversions
+        ]
+        keyword_args_as_conversions = {
+            key: namespace_ctx.prevent_rendering_while_active(conv)
+            for key, conv in keyword_args_as_conversions.items()
+        }
+        return (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        )
 
     def _code_to_converter(
         self, converter_name: str, code: str, ctx: dict
@@ -462,7 +512,8 @@ class BaseConversion(typing.Generic[CT]):
             ctx[converter_name].conv_name = converter_name
         return ctx[converter_name]
 
-    NAME_TO_CODE_INPUT = "_name_to_code_input"
+    NAMESPACES = "_name_to_code_input"
+    CONVERTERS_CACHE = "_converters_cache"
 
     @classmethod
     def _init_ctx(cls, debug=None):
@@ -472,9 +523,10 @@ class BaseConversion(typing.Generic[CT]):
             "__name__": "_convtools",
             "__naive_values__": {},
             "__none__": cls._none,
-            cls.NAME_TO_CODE_INPUT: [{}],
-            cls.PREFIXED_HASH_TO_NAME: {},
+            cls.CONVERTERS_CACHE: {},
             cls.GENERATED_NAMES: set(),
+            cls.NAMESPACES: [{}],
+            cls.PREFIXED_HASH_TO_NAME: {},
         }
         return ctx
 
@@ -521,17 +573,14 @@ class BaseConversion(typing.Generic[CT]):
         main_converter_callable = converter_callable_cls(debug=debug, ctx=ctx)
         ctx["__main_converter_callable"] = main_converter_callable
 
+        args_to_skip = ("self", "cls", "_none", "_naive", "_labels")
         if signature:
+            (code_args, _, _, namespace_ctx,) = self.get_args_def_info(
+                ctx, args_to_skip=args_to_skip, for_top_level_converter=True
+            )
             signature_words = _pattern_word.findall(signature)
-            missing_args = (
-                set(
-                    _pattern_word.findall(
-                        self.get_args_def_code(
-                            for_top_level_converter=True,
-                        )
-                    )
-                )
-                - set(signature_words)
+            missing_args = set(_pattern_word.findall(code_args)) - set(
+                signature_words
             )
             if missing_args:
                 raise ConversionException(
@@ -542,41 +591,44 @@ class BaseConversion(typing.Generic[CT]):
                 raise ConversionException(
                     "choose either method or a class_method"
                 )
+            (code_args, _, _, namespace_ctx,) = self.get_args_def_info(
+                ctx,
+                as_kwargs=True,
+                args_to_skip=args_to_skip,
+                for_top_level_converter=True,
+            )
             signature = (
                 ("self, " if method else "")
                 + ("cls, " if class_method else "")
                 + (initial_code_input)
-                + (
-                    self.get_args_def_code(
-                        as_kwargs=True,
-                        for_top_level_converter=True,
-                    )
-                )
+                + code_args
             )
 
-        code = Code()
-        converter_name = self.gen_name(converter_name, ctx, self)
-        code.add_line(f"def {converter_name}({signature}):", 1)
-        code.add_line("global __naive_values__, __none__", 0)
-        code.add_line("_naive = __naive_values__", 0)
-        code.add_line("_none = __none__", 0)
-        if has_labels:
-            code.add_line("_labels = {}", 0)
-        else:
-            code.add_line("_labels = _none", 0)
+        with namespace_ctx:
+            code = Code()
+            converter_name = self.gen_name(converter_name, ctx, self)
+            code.add_line(f"def {converter_name}({signature}):", 1)
+            code.add_line("global __naive_values__, __none__", 0)
+            code.add_line("_naive = __naive_values__", 0)
+            code.add_line("_none = __none__", 0)
+            if has_labels:
+                code.add_line("_labels = {}", 0)
+            else:
+                code.add_line("_labels = _none", 0)
 
-        code.add_line(
-            f"return {self.gen_code_and_update_ctx(initial_code_input, ctx)}",
-            0,
-        )
+            code_str = self.gen_code_and_update_ctx(initial_code_input, ctx)
+            code.add_line(f"return {code_str}", 0)
+
         main_converter = self._code_to_converter(
             converter_name=converter_name,
             code=code.to_string(base_indent_level=0),
             ctx=ctx,
         )
         main_converter_callable.set_main_converter(main_converter)
-        del ctx[self.PREFIXED_HASH_TO_NAME]
+        del ctx[self.CONVERTERS_CACHE]
         del ctx[self.GENERATED_NAMES]
+        del ctx[self.NAMESPACES]
+        del ctx[self.PREFIXED_HASH_TO_NAME]
         return main_converter_callable
 
     def execute(self, *args, debug=None, **kwargs) -> typing.Any:
@@ -943,7 +995,9 @@ class NaiveConversion(BaseConversion):
     self_content_type = (
         BaseConversion.self_content_type
         ^ BaseConversion.ContentTypes.FUNCTION_OF_INPUT
-    )
+    ) | BaseConversion.ContentTypes.NAIVE_USAGE
+
+    types_to_repr = {type(None), bool, int}
 
     def __init__(self, value: typing.Any, name_prefix="v"):
         """
@@ -965,35 +1019,31 @@ class NaiveConversion(BaseConversion):
             self.code_str = value_name
 
         elif callable(value):
-            if hasattr(value, "conv_name") and isinstance(
-                getattr(value, "conv_name"), str
+            f_name = var_name_from_string(value_name)
+            if f_name:
+                self.name_prefix = f_name
+        else:
+            value_type = type(value)
+            if (
+                value_type in self.types_to_repr
+                or value_type is str
+                and len(value) < 128
+                and "%" not in value
+                and "{" not in value
             ):
-                self.value_name = getattr(value, "conv_name")
-            else:
-                f_name = var_name_from_string(value_name)
-                if f_name:
-                    self.name_prefix = f_name
+                self.code_str = repr(value)
 
-    types_to_repr = {type(None), bool, int}
+        if self.code_str:
+            self.contents = self.contents ^ self.ContentTypes.NAIVE_USAGE
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
         if self.code_str:
             return self.code_str
 
-        value = self.value
-        value_type = type(value)
-        if (
-            value_type in self.types_to_repr
-            or value_type is str
-            and len(value) < 128
-            and "%" not in value
-            and "{" not in value
-        ):
-            return repr(value)
         value_name = self.value_name or self.gen_name(
-            self.name_prefix, ctx, value
+            self.name_prefix, ctx, self.value
         )
-        ctx["__naive_values__"][value_name] = value
+        ctx["__naive_values__"][value_name] = self.value
         return f'_naive["{value_name}"]'
 
     def is_itself_callable_like(self) -> typing.Optional[bool]:
@@ -1046,16 +1096,16 @@ class InputArg(BaseConversion):
         | BaseConversion.ContentTypes.ARG_USAGE
     ) ^ BaseConversion.ContentTypes.FUNCTION_OF_INPUT
 
-    def __init__(self, arg_name: str):
+    def __init__(self, name: str):
         """
         Args:
-          arg_name (string): argument name of the converter to be used
+          name (string): argument name of the converter to be used
         """
         super().__init__()
-        self.arg_name = arg_name
+        self.name = name
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
-        return self.arg_name
+        return self.name
 
 
 class LabelConversion(BaseConversion):
@@ -1081,56 +1131,102 @@ class LabelConversion(BaseConversion):
         return f"_labels[{repr(self.label_name)}]"
 
 
-class ConversionWrapper(BaseConversion):
-    """This is to be used in conjunction with NamedConversion.
+class Namespace(BaseConversion):
+    self_content_type = (
+        BaseConversion.self_content_type
+        ^ BaseConversion.ContentTypes.FUNCTION_OF_INPUT
+    )
 
-    ConversionWrapper is a map where:
-      - key is the name of NamedConversion used somewhere inside what the
-        ConversionWrapper wraps
-      - value is the piece of code to be used as input for NamedConversion
-    """
-
-    def __init__(self, conversion: typing.Any, name_to_code_input=None):
+    def __init__(
+        self, conversion: "typing.Any", name_to_code: "typing.Dict[str, str]"
+    ):
         super().__init__()
         self.conversion = self.ensure_conversion(conversion)
-        self._name_to_code_input = name_to_code_input
-
-    @classmethod
-    def name_to_code_input(
-        cls, ctx, name_to_code_input=None
-    ) -> typing.Dict[str, str]:
-        if name_to_code_input is None:
-            return ctx[cls.NAME_TO_CODE_INPUT][-1]
-        new_value: typing.Dict[str, str] = {}
-        new_value.update(cls.name_to_code_input(ctx))
-        new_value.update(name_to_code_input)
-        ctx[cls.NAME_TO_CODE_INPUT].append(new_value)
-        return new_value
+        self.name_to_code = name_to_code
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
-        pop_name_to_code_input = False
-        if self._name_to_code_input is not None:
-            pop_name_to_code_input = True
-            self.name_to_code_input(ctx, self._name_to_code_input)
-        result = self.conversion.gen_code_and_update_ctx(code_input, ctx)
-        if pop_name_to_code_input:
-            ctx[self.NAME_TO_CODE_INPUT].pop()
-        return result
+        with NamespaceCtx(self.name_to_code, ctx):
+            return self.conversion.gen_code_and_update_ctx(code_input, ctx)
+
+    def get_dependencies(self, types=None):
+        name_to_code = self.name_to_code
+        return (
+            dep
+            for dep in super().get_dependencies(types=types)
+            if not isinstance(dep, LazyEscapedString)
+            or dep.name not in name_to_code
+        )
 
 
-class NamedConversion(BaseConversion):
-    """See the ConversionWrapper docstring above"""
+class NamespaceCtx:
+    _name_to_code = None
+    ctx = None
+    active = False
 
-    def __init__(self, name, conversion):
+    NAMESPACES = BaseConversion.NAMESPACES
+
+    def __init__(self, name_to_code: "typing.Dict[str, str]", ctx):
+        if name_to_code:
+            self._name_to_code = name_to_code
+            self._ctx = ctx
+
+    def __enter__(self):
+        if self._name_to_code:
+            new_value: "typing.Dict[str, str]" = {}
+            new_value.update(self.name_to_code(self._ctx))
+            new_value.update(self._name_to_code)
+            self._ctx[self.NAMESPACES].append(new_value)
+        self.active = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self._name_to_code:
+            self._ctx[self.NAMESPACES].pop()
+        self.active = False
+
+    @classmethod
+    def name_to_code(cls, ctx) -> "typing.Dict[str, str]":
+        return ctx[cls.NAMESPACES][-1]
+
+    def prevent_rendering_while_active(self, conversion):
+        return NamespaceControlledUnit(self, conversion)
+
+
+class NamespaceControlledUnit(BaseConversion):
+    __slots__ = ["conversion", "namespace_ctx"]
+
+    def __init__(self, namespace_ctx: "NamespaceCtx", conversion):
         super().__init__()
+        self.namespace_ctx = namespace_ctx
         self.conversion = self.ensure_conversion(conversion)
+
+    def _gen_code_and_update_ctx(self, code_input, ctx):
+        if self.namespace_ctx.active:
+            raise Exception(
+                "rendering prevented by parent NamespaceCtx, "
+                "move rendering out"
+            )
+        return self.conversion.gen_code_and_update_ctx(code_input, ctx)
+
+
+class LazyEscapedString(BaseConversion):
+    self_content_type = (
+        BaseConversion.self_content_type
+        ^ BaseConversion.ContentTypes.FUNCTION_OF_INPUT
+    )
+
+    def __init__(self, name):
+        super().__init__()
         self.name = name
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
-        name_to_code_input = ConversionWrapper.name_to_code_input(ctx)
-        if self.name in name_to_code_input:
-            code_input = name_to_code_input[self.name]
-        return self.conversion.gen_code_and_update_ctx(code_input, ctx)
+        code = NamespaceCtx.name_to_code(ctx)[self.name]
+        if code is True:
+            return code_input
+        if code:
+            return code
+
+        raise ValueError("LazyEscapedString is left uninitialized", self.name)
 
 
 class Or(BaseConversion):
@@ -1290,6 +1386,8 @@ class GetItem(BaseMethodConversion):
     If an index is a conversion itself, then it is being calculated
     against an input."""
 
+    prefix = "item_or_default"
+
     def __init__(
         self,
         *indexes,
@@ -1322,48 +1420,108 @@ class GetItem(BaseMethodConversion):
                 code_output = self.wrap_path_item(code_output, code_index)
             return code_output
 
-        self_is_overwritten = code_self != code_input
-        code_output = "self_" if self_is_overwritten else "obj_"
-        for index in self.indexes:
-            code_index = index.gen_code_and_update_ctx("obj_", ctx)
-            code_output = self.wrap_path_item(code_output, code_index)
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
 
-        converter_name = self.gen_name(
-            "get_or_default",
-            ctx,
-            self,
-        )
-        converter_code = GET_OR_DEFAULT_TEMPLATE.format(
-            code_args=(
-                "self_, obj_, default_"
-                if self_is_overwritten
-                else "obj_, default_"
+        with namespace_ctx:
+            function_of_input_type = self.ContentTypes.FUNCTION_OF_INPUT
+            caching_is_impossible = (
+                not isinstance(self.default, NaiveConversion)
+                or any(
+                    index.contents & function_of_input_type
+                    for index in self.indexes
+                )
+                and not PipeConversion.input_is_simple(code_input)
             )
-            + self.get_args_def_code(),
-            converter_name=converter_name,
-            get_or_default_code=code_output,
-        )
-        self._code_to_converter(
-            converter_name=converter_name,
-            code=converter_code,
-            ctx=ctx,
-        )
-        # default_code = self.default.gen_code_and_update_ctx(code_input, ctx)
-        result = EscapedString(converter_name)
-        if self_is_overwritten:
-            result = result.call(
-                EscapedString(code_self),
-                GetItem(),
-                self.default,
-                *self.get_args_as_func_args(),
-            )
-        else:
-            result = result.call(
-                GetItem(),
-                self.default,
-                *self.get_args_as_func_args(),
-            )
-        return result.gen_code_and_update_ctx(code_input, ctx)
+
+            args_as_def_names = ["data_"]
+            args_as_conversions = [This()]
+            code_output = "data_"
+
+            if code_self != code_input:
+                args_as_def_names.append("self_")
+                args_as_conversions.append(EscapedString(code_self))
+                code_output = "self_"
+
+            if caching_is_impossible:
+                default_code = self.default.gen_code_and_update_ctx(
+                    "data_", ctx
+                )
+            else:
+                args_as_def_names.append("default_")
+                args_as_conversions.append(self.default)
+                default_code = "default_"
+
+            if caching_is_impossible:
+                for index in self.indexes:
+                    code_index = index.gen_code_and_update_ctx("data_", ctx)
+                    code_output = self.wrap_path_item(code_output, code_index)
+
+                positional_args_as_conversions = chain(
+                    args_as_conversions, positional_args_as_conversions
+                )
+                code_args = f"{', '.join(args_as_def_names)}{code_args}"
+
+                converter_name = self.gen_name(self.prefix, ctx, (self, -1))
+                converter_code = GET_OR_DEFAULT_TEMPLATE.format(
+                    code_args=code_args,
+                    converter_name=converter_name,
+                    get_or_default_code=code_output,
+                    default_code=default_code,
+                )
+                self._code_to_converter(
+                    converter_name=converter_name,
+                    code=converter_code,
+                    ctx=ctx,
+                )
+                resulting_conversion = EscapedString(converter_name).call(
+                    *positional_args_as_conversions,
+                    **keyword_args_as_conversions,
+                )
+            else:
+
+                key = (self.prefix, code_args, len(self.indexes))
+
+                if key not in ctx[self.CONVERTERS_CACHE]:
+                    for i, index in enumerate(self.indexes):
+                        var_index = f"index_{i}"
+                        args_as_def_names.append(var_index)
+                        code_output = self.wrap_path_item(
+                            code_output, var_index
+                        )
+
+                    code_args = f"{', '.join(args_as_def_names)}{code_args}"
+
+                    converter_name = self.gen_name(
+                        self.prefix, ctx, (self, len(self.indexes))
+                    )
+                    converter_code = GET_OR_DEFAULT_TEMPLATE.format(
+                        code_args=code_args,
+                        converter_name=converter_name,
+                        get_or_default_code=code_output,
+                        default_code=default_code,
+                    )
+                    self._code_to_converter(
+                        converter_name=converter_name,
+                        code=converter_code,
+                        ctx=ctx,
+                    )
+                    ctx[self.CONVERTERS_CACHE][key] = converter_name
+
+                else:
+                    converter_name = ctx[self.CONVERTERS_CACHE][key]
+
+                resulting_conversion = EscapedString(converter_name).call(
+                    *args_as_conversions,
+                    *self.indexes,
+                    *positional_args_as_conversions,
+                    **keyword_args_as_conversions,
+                )
+        return resulting_conversion.gen_code_and_update_ctx(code_input, ctx)
 
 
 class GetAttr(GetItem):
@@ -1374,6 +1532,7 @@ class GetAttr(GetItem):
     against an input."""
 
     valid_attr = re.compile(r"^'[A-Za-z_][a-zA-Z0-9_]*'$")
+    prefix = "attr_or_default"
 
     def wrap_path_item(self, code_input, path_item):
         if self.valid_attr.match(path_item):
@@ -1494,13 +1653,13 @@ class SortConversion(BaseConversion):
         super().__init__()
         self.sorted_kwargs = {}
         if key is not None:
-            self.sorted_kwargs["key"] = key
+            self.sorted_kwargs["key"] = self.ensure_conversion(key)
         if reverse:
-            self.sorted_kwargs["reverse"] = reverse
+            self.sorted_kwargs["reverse"] = self.ensure_conversion(reverse)
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
         return (
-            NaiveConversion(sorted)
+            EscapedString("sorted")
             .call(EscapedString(code_input), **self.sorted_kwargs)
             .gen_code_and_update_ctx("NOT_NEEDED_OR_BUG", ctx)
         )
@@ -1589,19 +1748,24 @@ class BaseComprehensionConversion(BaseConversion):
         return self.item.gen_code_and_update_ctx(code_input, ctx)
 
     def gen_generator_code(self, code_input, ctx):
-        param_name = self.gen_name("i", ctx, self)
-        item_code = self.gen_item_code(param_name, ctx)
-        gen_code = f"{item_code} for {param_name} in {code_input}"
+        suffix = self.gen_name("", ctx, self)
+        param_code = f"i_{suffix}"
+        for_params_code = param_code
+
+        item_code = self.gen_item_code(param_code, ctx)
+        gen_code = f"{item_code} for {for_params_code} in {code_input}"
+
         if self.where is not None:
             condition_code = self.where.gen_code_and_update_ctx(
-                param_name, ctx
+                param_code, ctx
             )
             if condition_code == "True":
                 pass
             elif condition_code == "False":
-                gen_code = f"{item_code} for {param_name} in ()"
+                gen_code = ""
             else:
                 gen_code = f"{gen_code} if {condition_code}"
+
         return gen_code
 
 
@@ -1759,30 +1923,42 @@ class BaseCollectionConversion(BaseConversion):
         inner_code_input = "data_"
         code = Code()
         converter_name = self.gen_name("optional_items_generator", ctx, self)
-        code_args = self.get_args_def_code(as_kwargs=False)
-        code.add_line(f"def {converter_name}(data_{code_args}):", 1)
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
+        with namespace_ctx:
+            code.add_line(f"def {converter_name}(data_{code_args}):", 1)
 
-        for condition, item in self.condition_to_item_pairs:
-            value_code = ensure_conversion(item).gen_code_and_update_ctx(
-                inner_code_input, ctx
-            )
-            if condition is not None:
-                condition_code = condition.gen_code_and_update_ctx(
+            for condition, item in self.condition_to_item_pairs:
+                value_code = ensure_conversion(item).gen_code_and_update_ctx(
                     inner_code_input, ctx
                 )
-                code.add_line(f"if {condition_code}:", 1)
-                code.add_line(f"yield {value_code}", -1)
-            else:
-                code.add_line(f"yield {value_code}", 0)
+                if condition is not None:
+                    condition_code = condition.gen_code_and_update_ctx(
+                        inner_code_input, ctx
+                    )
+                    code.add_line(f"if {condition_code}:", 1)
+                    code.add_line(f"yield {value_code}", -1)
+                else:
+                    code.add_line(f"yield {value_code}", 0)
 
-        generator_converter = self._code_to_converter(
-            converter_name=converter_name,
-            code=code.to_string(base_indent_level=0),
-            ctx=ctx,
+            self._code_to_converter(
+                converter_name=converter_name,
+                code=code.to_string(base_indent_level=0),
+                ctx=ctx,
+            )
+        return (
+            EscapedString(converter_name)
+            .call(
+                This(),
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
+            )
+            .gen_code_and_update_ctx(code_input, ctx)
         )
-        return CallFunc(
-            generator_converter, GetItem(), *self.get_args_as_func_args()
-        ).gen_code_and_update_ctx(code_input, ctx)
 
     def gen_joined_items_code(self, code_input, ctx):
         return ",".join(
@@ -1985,31 +2161,41 @@ class TakeWhile(BaseConversion):
         var_it = f"it{suffix}"
         var_item = f"item{suffix}"
 
-        def_args = self.get_args_def_code()
-        args = self.get_args_as_func_args()
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
+        with namespace_ctx:
+            condition_code = self.condition.gen_code_and_update_ctx(
+                var_item, ctx
+            )
 
-        condition_code = self.condition.gen_code_and_update_ctx(var_item, ctx)
+            code = Code()
+            code.add_line(f"def {converter_name}({var_it}{code_args}):", 1)
+            code.add_line(f"for {var_item} in {var_it}:", 1)
+            code.add_line(f"if {condition_code}:", 1)
+            if self.filter_results_conditions is None:
+                code.add_line(f"yield {var_item}", -1)
+            else:
+                filter_code = And(
+                    *self.filter_results_conditions
+                ).gen_code_and_update_ctx(var_item, ctx)
+                code.add_line(f"if {filter_code}:", 1)
+                code.add_line(f"yield {var_item}", -2)
 
-        code = Code()
-        code.add_line(f"def {converter_name}({var_it}{def_args}):", 1)
-        code.add_line(f"for {var_item} in {var_it}:", 1)
-        code.add_line(f"if {condition_code}:", 1)
-        if self.filter_results_conditions is None:
-            code.add_line(f"yield {var_item}", -1)
-        else:
-            filter_code = And(
-                *self.filter_results_conditions
-            ).gen_code_and_update_ctx(var_item, ctx)
-            code.add_line(f"if {filter_code}:", 1)
-            code.add_line(f"yield {var_item}", -2)
+            code.add_line("else:", 1)
+            code.add_line("break", -2)
 
-        code.add_line("else:", 1)
-        code.add_line("break", -2)
-
-        self._code_to_converter(converter_name, code.to_string(0), ctx)
-        result = EscapedString(converter_name).call(This(), *args)
-        if self.cast is not self._none:
-            result = result.as_type(self.cast)
+            self._code_to_converter(converter_name, code.to_string(0), ctx)
+            result = EscapedString(converter_name).call(
+                This(),
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
+            )
+            if self.cast is not self._none:
+                result = result.as_type(self.cast)
         return result.gen_code_and_update_ctx(code_input, ctx)
 
 
@@ -2029,26 +2215,37 @@ class DropWhile(BaseConversion):
         var_it = f"it{suffix}"
         var_item = f"item{suffix}"
 
-        def_args = self.get_args_def_code()
-        args = self.get_args_as_func_args()
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
+        with namespace_ctx:
+            condition_code = self.condition.gen_code_and_update_ctx(
+                var_item, ctx
+            )
 
-        condition_code = self.condition.gen_code_and_update_ctx(var_item, ctx)
-
-        code = Code()
-        code.add_line(
-            f"def {converter_name}({var_it},{var_chain}{def_args}):", 1
-        )
-        code.add_line(f"{var_it} = iter({var_it})", 0)
-        code.add_line(f"for {var_item} in {var_it}:", 1)
-        code.add_line(f"if not ({condition_code}):", 1)
-        code.add_line("break", -2)
-        code.add_line("else:", 1)
-        code.add_line("return ()", -1)
-        code.add_line(f"return {var_chain}(({var_item},), {var_it})", -1)
-        self._code_to_converter(converter_name, code.to_string(0), ctx)
+            code = Code()
+            code.add_line(
+                f"def {converter_name}({var_it},{var_chain}{code_args}):", 1
+            )
+            code.add_line(f"{var_it} = iter({var_it})", 0)
+            code.add_line(f"for {var_item} in {var_it}:", 1)
+            code.add_line(f"if not ({condition_code}):", 1)
+            code.add_line("break", -2)
+            code.add_line("else:", 1)
+            code.add_line("return ()", -1)
+            code.add_line(f"return {var_chain}(({var_item},), {var_it})", -1)
+            self._code_to_converter(converter_name, code.to_string(0), ctx)
         return (
             EscapedString(converter_name)
-            .call(This(), NaiveConversion(chain), *args)
+            .call(
+                This(),
+                NaiveConversion(chain),
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
+            )
             .gen_code_and_update_ctx(code_input, ctx)
         )
 
@@ -2133,6 +2330,7 @@ class PipeConversion(BaseConversion):
         if self.label_input or self.label_output:
             self.self_content_type |= self.ContentTypes.NEW_LABEL
             self.contents |= self.self_content_type
+            self.input_args_container.contents |= self.ContentTypes.NEW_LABEL
 
     def replace(self, where):
         return PipeConversion(
@@ -2223,59 +2421,55 @@ class PipeConversion(BaseConversion):
         var_result = f"result{suffix}"
         var_input = f"input{suffix}"
 
-        if code_input_is_ignored:
-            if self.label_output is None:
-                raise AssertionError("what are we doing here? it's a bug")
-            what_code, where_code = (where_code, var_input)
-        else:
-            if reducer_inputs_backup_needed:
-                ctx[key_to_backup].append(False)
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.input_args_container.get_args_def_info(ctx)
 
-            where_code = where.gen_code_and_update_ctx(var_input, ctx)
+        with namespace_ctx:
 
-            if reducer_inputs_backup_needed:
-                ctx[key_to_backup].pop()
+            if code_input_is_ignored:
+                if self.label_output is None:
+                    raise AssertionError("what are we doing here? it's a bug")
+                what_code, where_code = (where_code, var_input)
+            else:
+                if reducer_inputs_backup_needed:
+                    ctx[key_to_backup].append(False)
 
-        code_args = self.input_args_container.get_args_def_code()
-        where_args = self.input_args_container.get_args_as_func_args()
+                where_code = where.gen_code_and_update_ctx(var_input, ctx)
 
-        if self.label_input or self.label_output:
-            label_input_code = (
-                "\n".join(
-                    f"    _labels['{label_name}'] = "
-                    f"{label_conv.gen_code_and_update_ctx(var_input, ctx)}"
-                    for label_name, label_conv in self.label_input.items()
-                )
-                if self.label_input
-                else "    pass"
-            )
-            label_output_code = (
-                "\n".join(
-                    f"    _labels['{label_name}'] = "
-                    f"{label_conv.gen_code_and_update_ctx( var_result, ctx)}"
-                    for label_name, label_conv in self.label_output.items()
-                )
-                if self.label_output
-                else "    pass"
-            )
-            code = f"""
-def {converter_name}({var_input}{code_args}):
-{label_input_code}
-    {var_result} = {where_code}
-{label_output_code}
-    return {var_result}
-        """
-        else:
-            code = f"""
-def {converter_name}({var_input}{code_args}):
-    return {where_code}
-        """
+                if reducer_inputs_backup_needed:
+                    ctx[key_to_backup].pop()
+
+            code = Code()
+            code.add_line(f"def {converter_name}({var_input}{code_args}):", 1)
+
+            if self.label_input:
+                for label_name, label_c in self.label_input.items():
+                    code.add_line(
+                        f"_labels['{label_name}'] = "
+                        f"{label_c.gen_code_and_update_ctx(var_input, ctx)}",
+                        0,
+                    )
+            if self.label_output:
+                code.add_line(f"{var_result} = {where_code}", 0)
+                for label_name, label_c in self.label_output.items():
+                    code.add_line(
+                        f"_labels['{label_name}'] = "
+                        f"{label_c.gen_code_and_update_ctx(var_result, ctx)}",
+                        0,
+                    )
+                code.add_line(f"return {var_result}", 0)
+            else:
+                code.add_line(f"return {where_code}", 0)
 
         # no need in catching the function, we'll just use it by the name
         if reducers_run_stage != "collecting_reducer_inputs":
             self._code_to_converter(
                 converter_name=converter_name,
-                code=code,
+                code=code.to_string(0),
                 ctx=ctx,
             )
 
@@ -2283,7 +2477,8 @@ def {converter_name}({var_input}{code_args}):
             EscapedString(converter_name)
             .call(
                 EscapedString(what_code),
-                *where_args,
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
             )
             .gen_code_and_update_ctx(None, ctx)
         )
@@ -2302,20 +2497,31 @@ class TapConversion(BaseConversion):
         ]
 
     def _gen_code_and_update_ctx(self, code_input, ctx):
-        converter_name = self.gen_name("tap", ctx, self)
-        code_args = self.get_args_def_code(as_kwargs=False)
-        code = Code()
-        code.add_line(f"def {converter_name}(data_{code_args}):", 1)
-        for mut in self.mutations:
-            code.add_line(mut.gen_code_and_update_ctx("data_", ctx), 0)
-        code.add_line("return data_", 0)
+        suffix = self.gen_name("", ctx, self)
+        converter_name = f"tap_{suffix}"
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
+        with namespace_ctx:
+            code = Code()
+            code.add_line(f"def {converter_name}(data_{code_args}):", 1)
+            for mut in self.mutations:
+                code.add_line(mut.gen_code_and_update_ctx("data_", ctx), 0)
+            code.add_line("return data_", 0)
 
-        self._code_to_converter(
-            converter_name, code.to_string(base_indent_level=0), ctx
-        )
+            self._code_to_converter(
+                converter_name, code.to_string(base_indent_level=0), ctx
+            )
         return (
             EscapedString(converter_name)
-            .call(self.obj, *self.get_args_as_func_args())
+            .call(
+                self.obj,
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
+            )
             .gen_code_and_update_ctx(code_input, ctx)
         )
 
@@ -2325,33 +2531,38 @@ class IterMutConversion(TapConversion):
     elements in-place. The result is a generator.
     IterMutConversion takes any number of mutations"""
 
-    code_template = """
-def {converter_name}(data_{code_args}):
-    for item_ in data_:
-{mut_stmts}
-        yield item_
-"""
-
     def _gen_code_and_update_ctx(self, code_input, ctx):
-        converter_name = self.gen_name(
-            "iter_mut",
-            ctx,
-            self,
-        )
-        code_args = self.get_args_def_code(as_kwargs=False)
-        code = Code()
-        code.add_line(f"def {converter_name}(data_{code_args}):", 1)
-        code.add_line("for item_ in data_:", 1)
-        for mut in self.mutations:
-            code.add_line(mut.gen_code_and_update_ctx("item_", ctx), 0)
-        code.add_line("yield item_", 0)
+        suffix = self.gen_name("", ctx, self)
+        converter_name = f"iter_mut_{suffix}"
+        code_item = f"item_{suffix}"
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
 
-        self._code_to_converter(
-            converter_name, code.to_string(base_indent_level=0), ctx
-        )
+        with namespace_ctx:
+            code = Code()
+            code.add_line(f"def {converter_name}(data_{code_args}):", 1)
+            code.add_line(f"for {code_item} in data_:", 1)
+            for mut in self.mutations:
+                code.add_line(
+                    mut.gen_code_and_update_ctx(f"{code_item}", ctx), 0
+                )
+
+            code.add_line(f"yield {code_item}", 0)
+
+            self._code_to_converter(
+                converter_name, code.to_string(base_indent_level=0), ctx
+            )
         return (
             EscapedString(converter_name)
-            .call(self.obj, *self.get_args_as_func_args())
+            .call(
+                self.obj,
+                *positional_args_as_conversions,
+                **keyword_args_as_conversions,
+            )
             .gen_code_and_update_ctx(code_input, ctx)
         )
 

--- a/src/convtools/columns.py
+++ b/src/convtools/columns.py
@@ -13,9 +13,9 @@ class ColumnRef(BaseConversion):
     conversion"""
 
     def __init__(self, name: str, id_=None):
-        super().__init__()
         if not isinstance(name, str):
             raise ValueError("name should be str")
+        super().__init__()
         self.name = name
         self.index: "t.Optional[t.Union[str, int]]" = None
         self.id_ = id_
@@ -106,6 +106,8 @@ class MetaColumns:
         return True
 
     def add(self, name, index, conversion):
+        if name is not None:
+            name = str(name)
         column_number = self.column_to_number[name]
         self.column_to_number[name] += 1
         state = 0

--- a/src/convtools/contrib/tables.py
+++ b/src/convtools/contrib/tables.py
@@ -21,6 +21,7 @@ from ..base import (
     If,
     InputArg,
     NaiveConversion,
+    This,
     ensure_conversion,
 )
 from ..columns import ColumnChanges, ColumnRef, MetaColumns
@@ -217,6 +218,13 @@ class Table:
                     for index in range(len(first_row)):
                         pending_changes |= columns.add(None, index, None)[1]
 
+            elif isinstance(first_row, str):
+                if header is True:
+                    pending_changes |= columns.add(first_row, None, This())[1]
+                    first_row = None
+                else:
+                    pending_changes |= columns.add(None, None, This())[1]
+                pending_changes |= ColumnChanges.MUTATE
             else:
                 raise ValueError(
                     "failed to infer header: unsupported row type",

--- a/src/convtools/contrib/tables.py
+++ b/src/convtools/contrib/tables.py
@@ -218,18 +218,13 @@ class Table:
                     for index in range(len(first_row)):
                         pending_changes |= columns.add(None, index, None)[1]
 
-            elif isinstance(first_row, str):
+            else:
                 if header is True:
                     pending_changes |= columns.add(first_row, None, This())[1]
                     first_row = None
                 else:
                     pending_changes |= columns.add(None, None, This())[1]
                 pending_changes |= ColumnChanges.MUTATE
-            else:
-                raise ValueError(
-                    "failed to infer header: unsupported row type",
-                    type(first_row),
-                )
 
         rows_objects: "t.List[t.Iterable]" = [rows]
         if first_row is not None:

--- a/tests/test_bad_conversions.py
+++ b/tests/test_bad_conversions.py
@@ -1,0 +1,71 @@
+from itertools import chain
+
+import pytest
+
+from convtools import conversion as c
+from convtools.base import BaseConversion, Code
+
+
+class BadDropWhile(BaseConversion):
+    """convtools implementation of :py:obj:`itertools.dropwhile`"""
+
+    def __init__(self, condition):
+        super().__init__()
+        self.condition = self.ensure_conversion(condition)
+        self.filter_results_conditions = None
+        self.cast = self._none
+
+    def _gen_code_and_update_ctx(self, code_input, ctx):
+        suffix = self.gen_name("_", ctx, ("take_while", self, code_input))
+        converter_name = f"drop_while{suffix}"
+        var_chain = f"chain{suffix}"
+        var_it = f"it{suffix}"
+        var_item = f"item{suffix}"
+
+        (
+            code_args,
+            positional_args_as_conversions,
+            keyword_args_as_conversions,
+            namespace_ctx,
+        ) = self.get_args_def_info(ctx)
+        with namespace_ctx:
+            condition_code = self.condition.gen_code_and_update_ctx(
+                var_item, ctx
+            )
+
+            code = Code()
+            code.add_line(
+                f"def {converter_name}({var_it},{var_chain}{code_args}):", 1
+            )
+            code.add_line(f"{var_it} = iter({var_it})", 0)
+            code.add_line(f"for {var_item} in {var_it}:", 1)
+            code.add_line(f"if not ({condition_code}):", 1)
+            code.add_line("break", -2)
+            code.add_line("else:", 1)
+            code.add_line("return ()", -1)
+            code.add_line(f"return {var_chain}(({var_item},), {var_it})", -1)
+            self._code_to_converter(converter_name, code.to_string(0), ctx)
+            return (
+                c.escaped_string(converter_name)
+                .call(
+                    c.this,
+                    c.naive(chain),
+                    *positional_args_as_conversions,
+                    **keyword_args_as_conversions,
+                )
+                .gen_code_and_update_ctx(code_input, ctx)
+            )
+
+
+def test_bad_namespace_usage():
+    with pytest.raises(
+        Exception, match="rendering prevented by parent NamespaceCtx"
+    ):
+        assert BadDropWhile(c.this < 100).gen_converter(debug=True)
+
+    with pytest.raises(
+        Exception, match="rendering prevented by parent NamespaceCtx"
+    ):
+        assert BadDropWhile(c.this < c.input_arg("abc")).gen_converter(
+            debug=True
+        )

--- a/tests/test_bad_conversions.py
+++ b/tests/test_bad_conversions.py
@@ -61,11 +61,9 @@ def test_bad_namespace_usage():
     with pytest.raises(
         Exception, match="rendering prevented by parent NamespaceCtx"
     ):
-        assert BadDropWhile(c.this < 100).gen_converter(debug=True)
+        assert BadDropWhile(c.this < 100).gen_converter()
 
     with pytest.raises(
         Exception, match="rendering prevented by parent NamespaceCtx"
     ):
-        assert BadDropWhile(c.this < c.input_arg("abc")).gen_converter(
-            debug=True
-        )
+        assert BadDropWhile(c.this < c.input_arg("abc")).gen_converter()

--- a/tests/test_doc__index_word_count.py
+++ b/tests/test_doc__index_word_count.py
@@ -88,6 +88,6 @@ def test_doc__index_word_count():
         )
         # Define the resulting converter function signature.  In fact this
         # isn't necessary if you don't need to specify default values
-    ).gen_converter(debug=True, signature="data_, top_n=None")
+    ).gen_converter(signature="data_, top_n=None")
 
     assert pipeline(input_data, top_n=3) == {"war": 4, "and": 4, "peace": 4}

--- a/tests/test_doc__quickstart_aggregation.py
+++ b/tests/test_doc__quickstart_aggregation.py
@@ -74,7 +74,7 @@ def test_doc__quickstart_aggregation():
                 ),
             }
         )
-        .gen_converter(debug=True)
+        .gen_converter()
     )
 
     assert converter(input_data) == [

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -3,6 +3,7 @@ from datetime import date
 import pytest
 
 from convtools import conversion as c
+from convtools.base import LazyEscapedString, Namespace
 
 
 def test_manually_defined_reducers():
@@ -205,6 +206,17 @@ def test_grouping():
             .aggregate(by + (c.reduce(c.ReduceFuncs.Sum, c.item("debit")),))
             .execute(data, debug=False)
         )
+
+    assert (
+        Namespace(
+            c.aggregate(
+                c.ReduceFuncs.Array(c.this.or_(LazyEscapedString("foo")))
+            )
+            + c.input_arg("tst"),
+            {"foo": "tst"},
+        ).execute(range(3), tst=[], debug=True)
+        == [[], 1, 2]
+    )
 
 
 # fmt: off

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -214,7 +214,7 @@ def test_grouping():
             )
             + c.input_arg("tst"),
             {"foo": "tst"},
-        ).execute(range(3), tst=[], debug=True)
+        ).execute(range(3), tst=[])
         == [[], 1, 2]
     )
 

--- a/tests/test_joins.py
+++ b/tests/test_joins.py
@@ -247,7 +247,7 @@ def test_nested_loop_joins():
             ),
         )
         .as_type(list)
-        .gen_converter(debug=False)
+        .gen_converter(debug=True)
     )
     assert join1(
         [

--- a/tests/test_joins.py
+++ b/tests/test_joins.py
@@ -247,7 +247,7 @@ def test_nested_loop_joins():
             ),
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter()
     )
     assert join1(
         [
@@ -496,7 +496,7 @@ def test_join_with_input_args():
             c.LEFT == c.RIGHT,
         )
         .as_type(list)
-        .execute(None, custom_left=range(3), custom_right=range(3), debug=True)
+        .execute(None, custom_left=range(3), custom_right=range(3))
     ) == [(0, 0), (1, 1), (2, 2)]
 
 

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -28,6 +28,7 @@ def test_mutation_item():
                 c.Mut.set_item(c.item("age"), c.item("age") >= 18),
                 c.Mut.del_item("to_del"),
                 c.Mut.custom(c.this.call_method("update", {"to_add": 2})),
+                c.this.call_method("update", {"to_add2": 4}),
             )
         ),
         label_input="_input",
@@ -42,6 +43,7 @@ def test_mutation_item():
             "_updated": now,
             28: True,
             "to_add": 2,
+            "to_add2": 4,
         }
     ]
 
@@ -88,7 +90,7 @@ def test_iter_mut_method():
     assert c.iter_mut(c.Mut.custom(c.this.call_method("append", 7))).as_type(
         list
     ).execute([[1], [2]]) == [[1, 7], [2, 7]]
-    assert (
+    result = (
         c.this.iter({"a": c.this})
         .iter_mut(
             c.Mut.set_item("b", c.item("a") + 1),
@@ -99,7 +101,8 @@ def test_iter_mut_method():
         )
         .as_type(list)
         .execute([1, 2, 3], debug=False)
-    ) == [
+    )
+    assert result == [
         {"a": 1, "b": 2, "c": 3, "d": 4},
         {"a": 2, "b": 3, "c": 4, "d": 5},
         {"a": 3, "b": 4, "c": 5, "d": 6},

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -69,7 +69,7 @@ def test_zip_in_aggregate():
                 ).as_type(list),
             }
         )
-        .gen_converter(debug=True)
+        .gen_converter()
     )
     assert converter(input_data) == [
         {

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -96,8 +96,17 @@ def test_table_base_init():
     )
     assert result == [{"COLUMN_0": 1, "COLUMN_1": 2, "COLUMN_2": 3}]
 
-    with pytest.raises(ValueError):
-        Table.from_rows([{1}])
+    assert list(
+        Table.from_rows([1, (1,), (2,)], header=True)
+        .update(**{"abc": c.col("1").item(0)})
+        .take("abc")
+        .into_iter_rows(dict)
+    ) == [
+        {"abc": 1},
+        {"abc": 2},
+    ]
+
+    Table.from_rows(range(3), header=False).update(a=c.col("COLUMN_0"))
 
     assert list(
         Table.from_rows(["name", "cde"], header=True).into_iter_rows(dict)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -99,6 +99,13 @@ def test_table_base_init():
     with pytest.raises(ValueError):
         Table.from_rows([{1}])
 
+    assert list(
+        Table.from_rows(["name", "cde"], header=True).into_iter_rows(dict)
+    ) == [{"name": "cde"}]
+    assert list(
+        Table.from_rows(["name", "cde"], header=False).into_iter_rows(dict)
+    ) == [{"COLUMN_0": "name"}, {"COLUMN_0": "cde"}]
+
 
 def test_table_take():
     result = list(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,63 +1,6 @@
-from collections import deque
-from itertools import chain
 from reprlib import Repr
-from sys import getsizeof, stderr
 
 
 _repr = Repr()
 _repr.maxdict = 1000
 repr = _repr.repr
-
-
-def total_size(o, handlers={}, verbose=False):
-    """Returns the approximate memory footprint an object and all of its contents.
-
-    Automatically finds the contents of the following builtin containers and
-    their subclasses:  tuple, list, deque, dict, set and frozenset.
-    To search other containers, add handlers to iterate over their contents:
-
-        handlers = {SomeContainerClass: iter,
-                    OtherContainerClass: OtherContainerClass.get_elements}
-
-    """
-    dict_handler = lambda d: chain.from_iterable(
-        (k, v)
-        for k, v in d.items()
-        if k
-        not in {
-            "sys",
-            "__builtins__",
-        }
-    )
-    all_handlers = {
-        tuple: iter,
-        list: iter,
-        deque: iter,
-        dict: dict_handler,
-        set: iter,
-        frozenset: iter,
-    }
-    all_handlers.update(handlers)  # user handlers take precedence
-    seen = set()  # track which object id's have already been seen
-    default_size = getsizeof(0)  # estimate sizeof object without __sizeof__
-
-    def sizeof(o):
-        if id(o) in seen:  # do not double count the same object
-            return 0
-        seen.add(id(o))
-        if isinstance(o, (list, dict)):
-            # dicts/lists can grow without shrinking
-            s = 1
-        else:
-            s = getsizeof(o, default_size)
-
-        if verbose:
-            print(s, type(o), repr(o), file=stderr)
-
-        for typ, handler in all_handlers.items():
-            if isinstance(o, typ):
-                s += sum(map(sizeof, handler(o)))
-                break
-        return s
-
-    return sizeof(o)


### PR DESCRIPTION
Features
++++++++

- added ``c.ReduceFuncs.ArraySorted`` reducer
- reworked ``GetItem`` and ``GetAttr`` to cache ``get_or_default`` methods
  based on number of indexes and args
- added support for single column tables (headers are always str still)

Misc
++++

- updated internals of arg def handling, made naive and labels optional
- removed ``NamedConversion`` and ``ConversionWrapper`` in favor of new
  ``LazyEscapedString``, ``Namespace`` and ``NamespaceCtx``. This lays better
  groundwork for future use of conversions which generate code around another
  named ones.
