### PR TITLE
contrib.model: reworked errors; added cast overrides; added model-/bu…

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,6 +14,7 @@ source =
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover
+    if TYPE_CHECKING:
 
     PY_VERSION
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,6 @@ jobs:
         isort src tests --check
     - name: Test with pytest
       run: |
-        pip install pytest pytest-cov 
-        pytest
+        pip install pytest pytest-cov pytest-benchmark
+        pytest --benchmark-skip
         bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,34 @@
+0.26.0 (2022-06-30)
+___________________
+
+Experimental - contrib.model:
++++++++++++++++++++++++++++++
+
+- reworked errors, returned by ``build`` and ``build_or_raise`` to allow for
+  automated errors processing (now it's clear where path ends and error info
+  starts)
+- now ``cast`` not only supports casters, but complex types too:
+  ``cast(t.List[t.Tuple[int]])``
+- now it's possible to force all-field casting on a model level via ``Meta.cast
+  = True`` class field
+- ``build`` and ``build_or_raise`` can also force children casting via
+  ``cast=True`` parameter (doesn't affect inner models as they have their own
+  controls)
+- now casting supports type-to-caster(s) overrides like:
+  ``cast(overrides={date: casters.DateFromStr("%m/%d/%Y")})``,
+  ``Meta.cast_overrides`` and ``build(..., cast_overrides={date: [...]})``
+- added ``validators.Decimal(max_digits, decimal_places)``
+- extended str caster to decode bytes and supported custom encodings like
+  ``casters.Str("utf-16")``
+- added quantization support to ``casters.DecimalLossy(quantize_exp, rounding)``
+- added ``typing.Tuple`` support (both validation and casting)
+
+Misc:
++++++
+
+- updated `c.or_` and `c.and_` to better flatten nested constructions
+
+
 0.25.2 (2022-06-24)
 ___________________
 

--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,9 @@ What's the workflow?
    obj, errors = build(ResponseModel[t.List[UserModel]], input_data)
 
    In [4]: obj
-   Out[4]: ResponseModel(data=[UserModel(name='John', age=21, addresses=[AddressModel(country=<Countries.BR: 'BR'>, state='SP', city='São Paulo', street=None)])])
+   Out[4]: ResponseModel(data=[
+               UserModel(name='John', age=21, addresses=[
+                   AddressModel(country=<Countries.BR: 'BR'>, state='SP', city='São Paulo', street=None)])])
 
    In [5]: obj.data[0].addresses[0].country
    Out[5]: <Countries.BR: 'BR'>
@@ -141,12 +143,8 @@ What's the workflow?
    input_data["data"][0]["age"] = 21.1
    obj, errors = build(ResponseModel[t.List[UserModel]], input_data)
 
-   In [8]: errors
-   Out[8]:
-   defaultdict(dict,
-               {'data': defaultdict(dict,
-                            {0: defaultdict(dict,
-                                         {'age': {'int_caster': 'losing fractional part: 21.1; if desired, use casters.IntLossy'}})})})
+   In [5]: errors
+   Out[5]: {'data': {0: {'age': {'__ERRORS': {'int_caster': 'losing fractional part: 21.1; if desired, use casters.IntLossy'}}}}}
 
 
 **Contrib / Table** - stream processing of table-like data

--- a/docs/api/convtools.contrib.models.casters.rst
+++ b/docs/api/convtools.contrib.models.casters.rst
@@ -4,6 +4,14 @@ convtools.contrib.models.casters package
 Submodules
 ----------
 
+convtools.contrib.models.casters.base module
+--------------------------------------------
+
+.. automodule:: convtools.contrib.models.casters.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 convtools.contrib.models.casters.casters module
 -----------------------------------------------
 

--- a/docs/base_index.rst
+++ b/docs/base_index.rst
@@ -69,7 +69,9 @@ What's the workflow?
    obj, errors = build(ResponseModel[t.List[UserModel]], input_data)
 
    In [4]: obj
-   Out[4]: ResponseModel(data=[UserModel(name='John', age=21, addresses=[AddressModel(country=<Countries.BR: 'BR'>, state='SP', city='São Paulo', street=None)])])
+   Out[4]: ResponseModel(data=[
+               UserModel(name='John', age=21, addresses=[
+                   AddressModel(country=<Countries.BR: 'BR'>, state='SP', city='São Paulo', street=None)])])
    
    In [5]: obj.data[0].addresses[0].country
    Out[5]: <Countries.BR: 'BR'>
@@ -92,12 +94,8 @@ What's the workflow?
    input_data["data"][0]["age"] = 21.1
    obj, errors = build(ResponseModel[t.List[UserModel]], input_data)
 
-   In [8]: errors
-   Out[8]:
-   defaultdict(dict,
-               {'data': defaultdict(dict,
-                            {0: defaultdict(dict,
-                                         {'age': {'int_caster': 'losing fractional part: 21.1; if desired, use casters.IntLossy'}})})})
+   In [5]: errors
+   Out[5]: {'data': {0: {'age': {'__ERRORS': {'int_caster': 'losing fractional part: 21.1; if desired, use casters.IntLossy'}}}}}
 
 
 **Contrib / Table** - stream processing of table-like data

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -34,10 +34,10 @@ _________
        validate,
        validators,
    )
-   
+
    class AddressModel(DictModel):
        apt: int
-   
+
    class UserModel(DictModel):
        addresses: t.List[AddressModel] = (
            # Define field processing pipeline.
@@ -106,11 +106,10 @@ And when validation fails:
 
    user, errors = build(UserModel, {"age": 33.0})
 
-   In [4]: errors
-   Out[4]:
-   defaultdict(dict,
-               {'name': {'required': True},
-                'age': {'type': 'float instead of int'}})
+   In [3]: errors
+   Out[3]:
+   {'name': {'__ERRORS': {'required': True}},
+    'age': {'__ERRORS': {'type': 'float instead of int'}}}
 
 
 2. Validation - built-in & custom validators
@@ -126,6 +125,9 @@ Built-in validators:
 * :py:obj:`Custom<convtools.contrib.models.validators.validators.Custom>` - ``Custom("is_blank", lambda x: len(x))``
 * :py:obj:`Type<convtools.contrib.models.validators.validators.Type>` - ``Type(int, float)`` - this one
   is used under the hood to check output types
+* :py:obj:`Decimal<convtools.contrib.models.validators.validators.Decimal>` -
+  ``Decimal(max_digits, decimal_places)`` - checks total digits and decimal
+  places (`precision and scale PostgreSQL counterparts`)
 
 
 All-in-one example:
@@ -135,22 +137,22 @@ All-in-one example:
    class UserModel(DictModel):
        # either None or int (under the hood it's t.Union, so unions are supported too)
        user_id: t.Optional[int]
-   
+
        # field with default
        is_active: bool = True
        # or the same
        is_active: bool = field(default=True)
        # or the same
        is_active: bool = field(default_factory=lambda: True)
-   
+
        # any number of validators
        age: int = validate(validators.Gte(18), validators.Lt(100))
-   
+
        # custom getter + validation
        name: str = field(cls_method=True).validate(
            validators.Type(str), validators.Regex("[\w\s]+")
        )
-   
+
        @classmethod
        def get_name(cls, data):
            # returns data, errors
@@ -160,11 +162,11 @@ All-in-one example:
            if not name:
                return None, {"blank": True}
            return name, None
-   
+
        # if something needs to be cached on a single model instance level
        random_number: float = field(cls_method="get_random")
        same_random_number: float = field(cls_method="get_random")
-   
+
        @cached_model_method
        def get_random(self, data):
            # returns data, errors
@@ -184,26 +186,141 @@ All-in-one example:
 3. Type casting
 _______________
 
-Type casting is explicit and it's done in 2 cases:
+Type casting is explicit and is requested as follows:
+*****************************************************
 
-#. ``cast`` forces type casting (`either using passed casters OR by inferring
-   required casters from the expected output type`)
-#. model usage builds a model instance
+#. field level
 
-When ``cast()`` is run without arguments, the following built-in casters are
-inferred automatically:
+   .. code-block:: python
 
-* ``str``
-* ``float``
-* :py:obj:`Int<convtools.contrib.models.casters.casters.Int>` - casting ``10.1``
-  to int leads to a validation error (see ``IntLossy`` below)
-* :py:obj:`Decimal<convtools.contrib.models.casters.casters.Decimal>` -
-  initializing from floats with non-zero decimal part leads to a validation
-  error (see ``DecimalLossy`` below)
-* :py:obj:`List<convtools.contrib.models.casters.casters.List>`
-* :py:obj:`Dict<convtools.contrib.models.casters.casters.Dict>`
-* :py:obj:`Enum<convtools.contrib.models.casters.casters.Enum>`
-* :py:obj:`Union<convtools.contrib.models.casters.casters.Union>`
+      class TestModel(DictModel):
+          # infers required casters from the expected output type (uses
+          # default casters)
+          numbers: t.List[int] = cast()
+
+          # explicitly passing a caster - e.g. for custom date format
+          dt: date = cast(casters.DateFromStr("%m/%d/%Y"))
+
+          # explicitly casting to a type (including complex ones)
+          value: t.Any = cast(t.List[t.Tuple[int]])
+
+          # automatically inferring casters, but passing overrides for
+          # particular types
+          dates: t.List[date] = cast(overrides={date: casters.DateFromStr("%m/%d/%Y")})
+
+#. model level
+
+   .. code-block:: python
+
+      class TestModel(DictModel):
+          # model-level casting is enforced
+          dates: t.List[date]
+
+          # model-level casting is NOT enforced, since this field has it's own
+          # field processing pipeline defined
+          dt: date = field("data", "dt")
+
+          class Meta:
+              # forcing to cast all fields, where there's no field processing
+              # pipeline defined (no field/cast/validate calls)
+              cast = True
+              # model level overrides, which apply to all fields;
+              # field-level overrides have priority over model-level ones
+              cast_overrides = {
+                  date: casters.DateFromStr("%m/%d/%Y")
+              }
+
+
+#. builder level
+
+   .. code-block:: python
+
+      # models are self-sufficient, no upper level casting and overrides affect
+      # them
+      class TestModel(DictModel):
+          # hence, only validation is happening here
+          dt: int
+
+      # builder level casting & overrides affect everything but models;
+      # so in this case "build":
+      #  - casts any iterable of 2 elements to the tuple of 2 elements
+      #  - casts first element of the tuple to date, parsing it using US date
+      #    format
+      data, errors = build(
+          t.Tuple[date, TestModel],
+          cast=True,
+          cast_overrides = {
+              date: casters.DateFromStr("%m/%d/%Y")
+          }
+      )
+#. and also the model usage itself causes building a model instance (kind of
+   casting too).
+
+.. note::
+
+   All cast overrides support type-to-multiple-casters format. It then acts
+   like auto-casting to t.Union, trying to cast to every type from left to
+   right until the first success.
+
+   .. code-block:: python
+
+      # e.g. model-level cast overrides, field-level casting
+      class TestModel(DictModel):
+          dt: date = cast()
+
+          class Meta:
+              cast_overrides = {
+                  date: [
+                      casters.DateFromStr("%m/%d/%Y"),
+                      casters.DateFromStr("%d-%m-%Y"),
+                      casters.DateFromStr("%Y-%m-%d"),
+                  ]
+              }
+
+When ``cast()`` is run without arguments (failures generate proper errors):
+***************************************************************************
+
+* ``str`` - :py:obj:`Str<convtools.contrib.models.casters.casters.Str>` casts
+  to str; bytes are decoded using "utf-8" encoding
+* ``float`` - data is wrapped like ``float(data)``
+* ``int`` - :py:obj:`Int<convtools.contrib.models.casters.casters.Int>` casts
+  to int; casting ``10.1`` to int leads to a validation error (see ``IntLossy``
+  below)
+* ``Decimal`` -
+  :py:obj:`Decimal<convtools.contrib.models.casters.casters.Decimal>` casts to
+  ``Decimal``; initializing from floats with non-zero decimal part leads to a
+  validation error (see ``DecimalLossy`` below)
+* ``date`` -
+  :py:obj:`DatetimeFromStr<convtools.contrib.models.casters.casters.DatetimeFromStr>`
+  casts to ``date``, using default format: ``"%Y-%m-%d"``
+* ``list`` and ``t.List`` ensures own and children types
+* ``tuple`` and ``t.Tuple`` ensures own and children types
+* ``dict`` and ``t.Dict`` ensures own and children types
+* ``Enum`` - :py:obj:`Enum<convtools.contrib.models.casters.casters.Enum>`
+  wraps input data with enum class, obtaining an instance
+* ``t.Optional`` leaves ``None`` as-is; tries to cast the rest to the given type
+* ``t.Union`` tries to cast the data to every given type from left to right
+  until the first success
+
+Built-in casters for explicit use:
+**********************************
+
+* :py:obj:`Str<convtools.contrib.models.casters.casters.Str>` - decodes bytes,
+  leaves str as-is, everything else is wrapped with ``str(data)`` - e.g.
+  ``Str("utf-16")``
+* :py:obj:`IntLossy<convtools.contrib.models.casters.casters.IntLossy>` - allows
+  to cast with data loss, e.g. 10.1 to 10
+* :py:obj:`DecimalLossy<convtools.contrib.models.casters.casters.DecimalLossy>` -
+  allows to cast floats with non-zero decimal part to Decimal; supports
+  quantizing like ``casters.DecimalLossy(quantize_exp, rounding)``
+* :py:obj:`DateFromStr<convtools.contrib.models.casters.casters.DateFromStr>` - ``DateFromStr("%m/%d/%Y")``
+* :py:obj:`DatetimeFromStr<convtools.contrib.models.casters.casters.DatetimeFromStr>` - ``DatetimeFromStr("%m/%d/%Y %H:%M %p")``
+* :py:obj:`Custom<convtools.contrib.models.casters.casters.Custom>` - ``Custom("float_caster", float, (TypeError, ValueError))``
+* :py:obj:`CustomUnsafe<convtools.contrib.models.casters.casters.CustomUnsafe>` - ``CustomUnsafe(int)`` - can raise exceptions
+
+
+Response examples:
+******************
 
 .. code-block:: python
 
@@ -214,13 +331,12 @@ inferred automatically:
        number: Decimal = cast()
 
 
-   In [38]: build(UserModel, {"numbers": [1, 2.0, 2.5], "number": 1.1})
-   Out[38]:
+   In [6]: build(UserModel, {"numbers": [1, 2.0, 2.5], "number": 1.1})
+   Out[6]:
    (None,
-    defaultdict(dict,
-                {'numbers': defaultdict(dict,
-                             {2: {'int_caster': 'losing fractional part: 2.5; if desired, use casters.IntLossy'}}),
-                 'number': {'decimal_caster': 'imprecise init from float: 1.1; if desired, use casters.DecimalLossy'}}))
+    {'numbers': {2: {'__ERRORS': {'int_caster': 'losing fractional part: 2.5; if desired, use casters.IntLossy'}}},
+     'number': {'__ERRORS': {'decimal_caster': 'imprecise init from float: 1.1; if desired, use casters.DecimalLossy'}}})
+
     # to explain what happens when casting 1.1 float to Decimal
     # In [15]: Decimal(1.1)
     # Out[15]: Decimal('1.100000000000000088817841970012523233890533447265625')
@@ -230,26 +346,6 @@ inferred automatically:
    Out[39]: (UserModel(numbers=[1, 2, 2], number=Decimal('1')), None)
 
 
-Along with the above, the following casters are available for explicit use:
-
-* :py:obj:`IntLossy<convtools.contrib.models.casters.casters.IntLossy>` - allows
-  to cast with data loss, e.g. 10.1 to 10
-* :py:obj:`DecimalLossy<convtools.contrib.models.casters.casters.DecimalLossy>`
-  - allows to cast floats with non-zero decimal part to Decimal
-* :py:obj:`DateFromStr<convtools.contrib.models.casters.casters.DateFromStr>` - ``DateFromStr("%m/%d/%Y")``
-* :py:obj:`DatetimeFromStr<convtools.contrib.models.casters.casters.DatetimeFromStr>` - ``DatetimeFromStr("%m/%d/%Y %H:%M %p")``
-* :py:obj:`Custom<convtools.contrib.models.casters.casters.Custom>` - ``Custom("float_caster", float, (TypeError, ValueError))``
-* :py:obj:`CustomUnsafe<convtools.contrib.models.casters.casters.CustomUnsafe>` - ``CustomUnsafe(int)`` - can raise exceptions
-
-.. code-block:: python
-
-   class UserModel(DictModel):
-       numbers: t.List[int] = cast(casters.List(casters.IntLossy()))
-
-   In [8]: build(UserModel, {"numbers": [1, 2.0, 2.5]})
-   Out[8]: (UserModel(numbers=[1, 2, 2]), None)
-
-
 As we mentioned above, model usage in type definition is the 2nd case when data
 mutates -- as it builds model instances:
 
@@ -257,7 +353,7 @@ mutates -- as it builds model instances:
 
    class AddressModel(DictModel):
        apt: int = cast()
-   
+
    class UserModel(DictModel):
        addresses: t.List[AddressModel]
 
@@ -267,7 +363,7 @@ mutates -- as it builds model instances:
 
    In [19]: user.name
    Out[19]: 'John'
-   
+
    In [20]: user.addresses[0].apt
    Out[20]: 221
 
@@ -275,6 +371,7 @@ mutates -- as it builds model instances:
    # the following works too:
    In [21]: build_or_raise(t.List[AddressModel], [{"apt": 221}])
    Out[21]: [AddressModel(apt=221)]
+
 
 
 4. Generic models
@@ -285,18 +382,18 @@ Generic models are supported.
 .. code-block:: python
 
    T = t.TypeVar("T")
-   
+
    class ResponseModel(DictModel, t.Generic[T]):
        data: t.List[T]
-   
+
    class UserModel(DictModel, t.Generic[T]):
        parameter: T = cast()
-   
-   
+
+
    response = build_or_raise(
        ResponseModel[UserModel[int]], {"data": [{"parameter": " 123 "}]}
    )
-   
+
    In [2]: response
    Out[2]: ResponseModel(data=[UserModel(parameter=123)])
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-benchmark
 pytest-cov
 towncrier
 flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = convtools
-version = 0.25.2
+version = 0.26.0
 description = convtools allows to define and reuse conversions for processing collections and csv tables, complex aggregations and joins.
 author = Nikita Almakov
 author_email = nikita.almakov@gmail.com

--- a/src/convtools/__init__.py
+++ b/src/convtools/__init__.py
@@ -3,4 +3,4 @@ This object exposes the public API of conversions."""
 from .conversion import conversion  # noqa: F401
 
 
-__version__ = "0.25.2"
+__version__ = "0.26.0"

--- a/src/convtools/contrib/models/base.py
+++ b/src/convtools/contrib/models/base.py
@@ -1,5 +1,7 @@
 """Defines base classes"""
+import abc
 from collections import namedtuple
+from typing import Dict, List, Optional, Type, Union
 
 
 _none = object()
@@ -7,6 +9,46 @@ _none = object()
 
 class BaseStep:
     STEP_TYPE = "base_step"
+    ensures_type: Optional[Type] = None
+
+
+TypeValueCodeGenArgs = namedtuple(
+    "TypeValueCodeGenArgs",
+    [
+        "code_suffix",
+        "code",
+        "type_value",
+        "name_code",
+        "data_code",
+        "errors_code",
+        "base_conversion",
+        "ctx",
+        "level",
+        "type_var_to_type_value",
+        "type_to_model_meta",
+        "cast",
+        "cast_overrides_stack",
+    ],
+)
+
+
+class BaseCaster(BaseStep, abc.ABC):
+    """Defines base caster (object which casts input data to a necessary type
+    or describes errors)"""
+
+    STEP_TYPE = "cast"
+    name = "base_caster"
+
+    @abc.abstractmethod
+    def to_code(self, args: TypeValueCodeGenArgs):
+        raise NotImplementedError
+
+
+CastOverrides = Union[
+    None,
+    Dict[Type, BaseCaster],
+    Dict[Type, List[BaseCaster]],
+]
 
 
 class BaseModel:
@@ -41,19 +83,96 @@ class ValidationError(BaseError):
     pass
 
 
-TypeValueCodeGenArgs = namedtuple(
-    "TypeValueCodeGenArgs",
-    [
-        "code_suffix",
-        "code",
-        "type_value",
-        "name_code",
-        "data_code",
-        "errors_code",
-        "base_conversion",
-        "ctx",
-        "level",
-        "type_var_to_type_value",
-        "type_to_model_meta",
-    ],
-)
+dict_getitem = dict.__getitem__
+dict_contains = dict.__contains__
+dict_delitem = dict.__delitem__
+
+
+class ErrorsDict(dict):
+    """This is a dict which acts like a defaultdict(dict) of any depth.
+    It also supports lazy entries."""
+
+    locked = False
+
+    def lock(self):
+        if self.locked is False:
+            self.locked = True
+        else:
+            self.locked[None] = None
+
+    def __getitem__(self, k):
+        try:
+            return dict_getitem(self, k)
+        except KeyError:
+            if self.locked:
+                raise
+
+            if k == "__ROOT":
+                return self
+
+            self[k] = value = ErrorsDict()
+            if self.locked is False:
+                value.locked = self.locked = {}
+            else:
+                value.locked = self.locked
+            return value
+
+    def __contains__(self, k):
+        if k == "__ROOT":
+            return self
+        return dict_contains(self, k)
+
+    def __delitem__(self, k):
+        if k == "__ROOT":
+            return self.clear()
+        dict_delitem(self, k)
+
+    def get_lazy_item(self, k):
+        if k == "__ROOT":
+            return self
+        if k in self:
+            return self[k]
+        return LazyErrorsDict(self, k)
+
+
+class LazyErrorsDict:
+    """A helper class which is a lazy entry of
+    :py:obj:`ErrorsDict<convtools.contrib.models.base.ErrorsDict>`"""
+
+    __slots__ = ("parent_errors_dict", "key", "value")
+
+    def __init__(self, parent_errors_dict, key):
+        self.parent_errors_dict = parent_errors_dict
+        self.key = key
+        self.value = None
+
+    def __getitem__(self, k):
+        if self.value is None:
+            self.value = self.parent_errors_dict[self.key]
+        return self.value[k]
+
+    def __setitem__(self, k, v):
+        if self.value is None:
+            self.value = self.parent_errors_dict[self.key]
+        self.value[k] = v
+
+    def __contains__(self, key):
+        if self.value is None:
+            return False
+        return key in self.value
+
+    def __delitem__(self, k):
+        if self.value is not None:
+            del self.value[k]
+
+            if not self.value:
+                del self.parent_errors_dict[self.key]
+                self.value = None
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def get_lazy_item(self, k):
+        if k == "__ROOT":
+            return self
+        return LazyErrorsDict(self, k)

--- a/src/convtools/contrib/models/casters/__init__.py
+++ b/src/convtools/contrib/models/casters/__init__.py
@@ -6,11 +6,9 @@ from .casters import (
     DatetimeFromStr,
     Decimal,
     DecimalLossy,
-    Dict,
     Enum,
     Int,
     IntLossy,
-    List,
-    Optional,
-    Union,
+    NaiveCaster,
+    Str,
 )

--- a/src/convtools/contrib/models/casters/base.py
+++ b/src/convtools/contrib/models/casters/base.py
@@ -1,0 +1,87 @@
+"""
+Contains base casters - objects which define type casting operation, including
+checking for corresponding validation errors.
+"""
+import abc
+from typing import TYPE_CHECKING
+
+from convtools import conversion as c
+from convtools.contrib.models.base import (
+    BaseCaster,
+    CastOverrides,
+    TypeValueCodeGenArgs,
+)
+
+
+if TYPE_CHECKING:
+    from typing import Type
+
+
+class SimpleCaster(BaseCaster, abc.ABC):
+    """Defines simple caster where self._cast method contains cast/validate
+    logic"""
+
+    def __init__(self, name):
+        self.name = name
+
+    @abc.abstractmethod
+    def _cast(self, field_name, data, errors):
+        """to be defined"""
+
+    def to_code(self, args: TypeValueCodeGenArgs):
+        args.code.add_line(
+            "{} = {}".format(  # pylint: disable=consider-using-f-string
+                args.data_code,
+                (
+                    c.naive(
+                        self._cast,
+                        name_prefix=f"{self.name}{args.code_suffix}{args.level}",
+                    )
+                    .call(
+                        c.escaped_string(args.name_code),
+                        c.escaped_string(args.data_code),
+                        c.escaped_string(args.errors_code),
+                    )
+                    .gen_code_and_update_ctx("not needed", args.ctx)
+                ),
+            ),
+            0,
+        )
+
+
+class CasterToFinalType(BaseCaster):
+    """Caster placeholder to be initialized with the caster to the output
+    type"""
+
+    def __init__(self, overrides: CastOverrides):
+        self.overrides = overrides
+
+    def to_code(self, args: TypeValueCodeGenArgs):
+        raise AssertionError("cannot be used directly")
+
+
+class TypeCaster(BaseCaster):
+    """Main caster which casts to a required type"""
+
+    def __init__(self, type_value: "Type", overrides: CastOverrides):
+        self.type_value = self.ensures_type = type_value
+        self.overrides = overrides
+
+    def to_code(self, args: TypeValueCodeGenArgs):
+        from ..type_handlers import (  # pylint: disable=import-outside-toplevel
+            type_value_to_code,
+        )
+
+        if self.overrides is None:
+            return type_value_to_code(
+                args._replace(type_value=self.type_value, cast=True)
+            )
+        return type_value_to_code(
+            args._replace(
+                type_value=self.type_value,
+                cast=True,
+                cast_overrides_stack=(
+                    (self.overrides,) + args.cast_overrides_stack
+                ),
+            )
+        )

--- a/src/convtools/contrib/models/casters/casters.py
+++ b/src/convtools/contrib/models/casters/casters.py
@@ -1,116 +1,14 @@
 """
-Contains casters - objects which define type casting operation, including
-checking for corresponding validation errors.
+Contains implementation of base casters.
 """
-import abc
-from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal as Decimal_
 from decimal import InvalidOperation
 
 from convtools import conversion as c
-from convtools.utils import Code
 
-from ..base import BaseStep
-
-
-class BaseCaster(BaseStep):
-    """Defines base caster (object which casts input data to a necessary type
-    or describes errors)"""
-
-    STEP_TYPE = "code_generative_caster"
-    name = "base_caster"
-
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        raise NotImplementedError
-
-    def as_conversion_function(
-        self,
-        caster_name_prefix,
-        code_suffix,
-        name_code,  # pylint: disable=unused-argument
-        data_code,  # pylint: disable=unused-argument
-        errors_code,  # pylint: disable=unused-argument
-        base_conversion,
-        ctx,
-        level,
-    ):
-        # TODO: think about carving this out to a separate function
-        converter_name = base_conversion.gen_name(
-            caster_name_prefix, ctx, self
-        )
-        code = Code()
-        code.add_line(f"def {converter_name}(name_, data_, errors_):", 1)
-        code.add_line("global __naive_values__", 0)
-        code.add_line("_naive = __naive_values__", 0)
-        conversion_code = self.as_conversion(
-            code_suffix,
-            "name_",
-            "data_",
-            "errors_",
-            base_conversion,
-            ctx,
-            level,
-        ).gen_code_and_update_ctx("data_", ctx)
-        code.add_line(f"return {conversion_code}", 0)
-        base_conversion.compile_converter(
-            converter_name=converter_name,
-            code=code.to_string(base_indent_level=0),
-            ctx=ctx,
-        )
-        return c.escaped_string(converter_name)
-
-
-class SimpleCaster(BaseCaster, abc.ABC):
-    """Defines simple caster where self.cast method contains cast/validate
-    logic"""
-
-    STEP_TYPE = "simple_caster"
-
-    def __init__(self, name):
-        self.name = name
-
-    @abc.abstractmethod
-    def cast(self, field_name, data, errors):
-        """to be defined"""
-
-    def as_conversion_function(
-        self,
-        caster_name_prefix,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return c.naive(self.cast, name_prefix=self.name)
-
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return c.naive(
-            self.cast, name_prefix=f"{self.name}{code_suffix}"
-        ).call(
-            c.escaped_string(name_code), c.this, c.escaped_string(errors_code)
-        )
+from ..base import BaseCaster, TypeValueCodeGenArgs
+from .base import SimpleCaster
 
 
 class CustomUnsafe(BaseCaster):
@@ -118,238 +16,44 @@ class CustomUnsafe(BaseCaster):
     catch any exceptions"""
 
     def __init__(self, func):
-        self.cast = func
+        self._cast = func
 
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return c.naive(
-            self.cast, name_prefix=f"unsafe_cast{code_suffix}"
-        ).call(c.this)
-
-
-class List(BaseCaster):
-    """Defines list caster which makes sure that it works with iterable and
-    then rebuilds a new list, running self.item_caster on every collection
-    item"""
-
-    name = "generic_list"
-
-    def __init__(self, item_caster):
-        self.item_caster = item_caster
-
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return c.naive(
-            self.cast, name_prefix=f"{self.name}{code_suffix}"
-        ).call(
-            self.item_caster.as_conversion_function(
-                "item_caster",
-                code_suffix,
-                name_code,
-                data_code,
-                errors_code,
-                base_conversion,
-                ctx,
-                level,
+    def to_code(self, args: TypeValueCodeGenArgs):
+        args.code.add_line(
+            "{} = {}".format(  # pylint: disable=consider-using-f-string
+                args.data_code,
+                (
+                    c.naive(
+                        self._cast,
+                        name_prefix=f"unsafe_cast{args.code_suffix}{args.level}",
+                    )
+                    .call(c.escaped_string(args.data_code))
+                    .gen_code_and_update_ctx("not needed", args.ctx)
+                ),
             ),
-            c.escaped_string(name_code),
-            c.this,
-            c.escaped_string(errors_code),
+            0,
         )
 
-    def cast(self, item_caster, field_name, data, errors):
-        try:
-            it = iter(data)
-        except TypeError:
-            errors[field_name]["type"] = f"{type(data).__name__} not iterable"
-            return
 
-        new_errors = defaultdict(dict)
-        new_data = [
-            item_caster(index, item, new_errors)
-            for index, item in enumerate(it)
-        ]
-        if new_errors:
-            errors[field_name] = new_errors
+class Str(SimpleCaster):
+    """Into str caster"""
+
+    ensures_type = str
+
+    def __init__(self, encoding="utf-8"):
+        super().__init__("into_str")
+        self.encoding = encoding
+
+    def _cast(self, field_name, data, errors):
+        if isinstance(data, str):
+            return data
+        if isinstance(data, bytes):
+            try:
+                return data.decode(self.encoding)
+            except Exception as e:  # pylint: disable=broad-except
+                errors[field_name]["__ERRORS"] = {"decoding": str(e)}
         else:
-            return new_data
-
-
-class Dict(BaseCaster):
-    """Defines list caster which makes sure that it works with a dict and then
-    rebuilds a new dict, running self.key_caster and self.value_caster on every
-    key-value pair"""
-
-    name = "generic_dict"
-
-    def __init__(self, key_caster, value_caster):
-        self.key_caster = key_caster
-        self.value_caster = value_caster
-        self.name = f"{self.name}_{key_caster.name}_{value_caster.name}"
-
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return c.naive(
-            self.cast, name_prefix=f"{self.name}{code_suffix}{level}"
-        ).call(
-            self.key_caster.as_conversion_function(
-                "key_caster",
-                code_suffix,
-                name_code,
-                data_code,
-                errors_code,
-                base_conversion,
-                ctx,
-                level,
-            ),
-            self.value_caster.as_conversion_function(
-                "value_caster",
-                code_suffix,
-                name_code,
-                data_code,
-                errors_code,
-                base_conversion,
-                ctx,
-                level,
-            ),
-            c.escaped_string(name_code),
-            c.this,
-            c.escaped_string(errors_code),
-        )
-
-    def cast(self, key_caster, value_caster, field_name, data, errors):
-        if not isinstance(data, dict):
-            errors[field_name][
-                "type"
-            ] = f"expected dict, got {type(data).__name__}"
-            return
-        key_errors = defaultdict(dict)
-        value_errors = defaultdict(dict)
-        new_data = {
-            key_caster(key, key, key_errors): value_caster(
-                key, value, value_errors
-            )
-            for key, value in data.items()
-        }
-        if key_errors or value_errors:
-            errors[field_name]["keys"] = key_errors
-            errors[field_name]["values"] = value_errors
-        else:
-            return new_data
-
-
-class CasterToFinalType(BaseCaster):
-    """Caster placeholder to be initialized with the caster to the output
-    type"""
-
-
-class Union(BaseCaster):
-    """Defines a caster which tries to run passed casters until the first
-    success."""
-
-    def __init__(self, *casters, accept_none=False):
-        self.casters = casters
-        self.accept_none = accept_none
-
-    def as_conversion(
-        self,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        return self.as_conversion_function(
-            "union",
-            code_suffix,
-            name_code,
-            data_code,
-            errors_code,
-            base_conversion,
-            ctx,
-            level,
-        ).call(
-            c.escaped_string(name_code), c.this, c.escaped_string(errors_code)
-        )
-
-    def as_conversion_function(
-        self,
-        caster_name_prefix,
-        code_suffix,
-        name_code,
-        data_code,
-        errors_code,
-        base_conversion,
-        ctx,
-        level,
-    ):
-        converter_name = base_conversion.gen_name(
-            caster_name_prefix, ctx, self
-        )
-        code = Code()
-        code.add_line(f"def {converter_name}(name_, data_, errors_):", 1)
-        code.add_line("global __naive_values__", 0)
-        code.add_line("_naive = __naive_values__", 0)
-
-        if self.accept_none:
-            code.add_line("if data_ is not None:", 1)
-
-        last_index = len(self.casters) - 1
-        for index, caster in enumerate(self.casters):
-            caster_code = caster.as_conversion(
-                code_suffix,
-                "name_",
-                "data_",
-                "errors_",
-                base_conversion,
-                ctx,
-                level,
-            ).gen_code_and_update_ctx("data_", ctx)
-
-            if index == last_index:
-                code.add_line(f"return {caster_code}", 0)
-            else:
-                code.add_line(f"result_ = {caster_code}", 0)
-                code.add_line("if name_ not in errors_:", 1)
-                code.add_line("return result_", -1)
-                code.add_line("del errors_[name_]", 0)
-
-        base_conversion.compile_converter(
-            converter_name=converter_name,
-            code=code.to_string(base_indent_level=0),
-            ctx=ctx,
-        )
-        return c.escaped_string(converter_name)
-
-
-def Optional(caster) -> Union:  # pylint: disable=invalid-name
-    return Union(caster, accept_none=True)
+            return str(data)
 
 
 class DatetimeFromStr(SimpleCaster):
@@ -359,13 +63,13 @@ class DatetimeFromStr(SimpleCaster):
         super().__init__("datetime_from_str")
         self.fmt = fmt
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
             return datetime.strptime(data, self.fmt)
         except (ValueError, TypeError):
-            errors[field_name][
-                self.name
-            ] = f"failed to parse date with: {self.fmt}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed to parse date with: {self.fmt}"
+            }
 
 
 class DateFromStr(SimpleCaster):
@@ -375,13 +79,13 @@ class DateFromStr(SimpleCaster):
         super().__init__("date_from_str")
         self.fmt = fmt
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
             return datetime.strptime(data, self.fmt).date()
         except (ValueError, TypeError):
-            errors[field_name][
-                self.name
-            ] = f"failed to parse date with: {self.fmt}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed to parse date with: {self.fmt}"
+            }
 
 
 class Enum(SimpleCaster):
@@ -389,13 +93,13 @@ class Enum(SimpleCaster):
         super().__init__("enum_caster")
         self.enum_cls = enum_cls
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
             return self.enum_cls(data)
         except ValueError:
-            errors[field_name][
-                self.name
-            ] = f"{self.enum_cls.__name__}: unknown value = {data}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"{self.enum_cls.__name__}: unknown value = {data}"
+            }
 
 
 class IntLossy(SimpleCaster):
@@ -406,7 +110,9 @@ class IntLossy(SimpleCaster):
     def __init__(self):
         super().__init__("int_lossy_caster")
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
+        if isinstance(data, int):
+            return data
         try:
             return int(data)
         except self.exceptions:
@@ -414,9 +120,9 @@ class IntLossy(SimpleCaster):
         try:
             return int(float(data))
         except self.exceptions:
-            errors[field_name][
-                self.name
-            ] = f"failed for type {type(data).__name__}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed for type {type(data).__name__}"
+            }
 
 
 class Int(SimpleCaster):
@@ -428,61 +134,96 @@ class Int(SimpleCaster):
     def __init__(self):
         super().__init__("int_caster")
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
+        if isinstance(data, int):
+            return data
         try:
             if not isinstance(data, str) and data % 1:
-                errors[field_name][self.name] = (
-                    f"losing fractional part: {data}; "
-                    "if desired, use casters.IntLossy"
-                )
-                return
-            return int(data)
+                errors[field_name]["__ERRORS"] = {
+                    self.name: (
+                        f"losing fractional part: {data}; "
+                        "if desired, use casters.IntLossy"
+                    )
+                }
+            else:
+                return int(data)
         except self.exceptions:
-            errors[field_name][
-                self.name
-            ] = f"failed for type {type(data).__name__}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed for type {type(data).__name__}"
+            }
+
+
+class NaiveCaster(SimpleCaster):
+    """Tries to cast anything to float"""
+
+    exceptions = (TypeError, ValueError)
+
+    def __init__(self, name, type_, exceptions):
+        super().__init__(name)
+        self.type_ = type_
+        self.exceptions = exceptions
+
+    def _cast(self, field_name, data, errors):
+        if isinstance(data, self.type_):
+            return data
+        try:
+            return self.type_(data)
+        except self.exceptions:
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed for type {type(data).__name__}"
+            }
 
 
 class DecimalLossy(SimpleCaster):
     """Tries to cast anything to Decimal, doesn't prevent initializing from
     floats with non-zero decimal parts"""
 
+    ensures_type = Decimal_
+
     exceptions = (TypeError, InvalidOperation)
 
-    def __init__(self):
+    def __init__(self, quantize_exp=None, rounding=None):
         super().__init__("decimal_lossy_caster")
+        self.quantize_exp = quantize_exp
+        self.rounding = rounding
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
-            return Decimal_(data)
+            if self.quantize_exp is None:
+                return Decimal_(data)
+            return Decimal_(data).quantize(self.quantize_exp, self.rounding)
         except self.exceptions:
-            errors[field_name][
-                self.name
-            ] = f"failed for type {type(data).__name__}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed for type {type(data).__name__}"
+            }
 
 
 class Decimal(SimpleCaster):
     """Tries to cast anything to Decimal, prevents initializing from
     floats with non-zero decimal parts"""
 
+    ensures_type = Decimal_
+
     exceptions = (TypeError, InvalidOperation)
 
     def __init__(self):
         super().__init__("decimal_caster")
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
             if isinstance(data, float) and data % 1:
-                errors[field_name][self.name] = (
-                    f"imprecise init from float: {data}; "
-                    "if desired, use casters.DecimalLossy"
-                )
+                errors[field_name]["__ERRORS"] = {
+                    self.name: (
+                        f"imprecise init from float: {data}; "
+                        "if desired, use casters.DecimalLossy"
+                    )
+                }
                 return
             return Decimal_(data)
         except self.exceptions:
-            errors[field_name][
-                self.name
-            ] = f"failed for type {type(data).__name__}"
+            errors[field_name]["__ERRORS"] = {
+                self.name: f"failed for type {type(data).__name__}"
+            }
 
 
 class Custom(SimpleCaster):
@@ -494,8 +235,8 @@ class Custom(SimpleCaster):
         self.func = func
         self.exc_to_silence = exc_to_silence
 
-    def cast(self, field_name, data, errors):
+    def _cast(self, field_name, data, errors):
         try:
             return self.func(data)
         except self.exc_to_silence:
-            errors[field_name][self.name] = "failed"
+            errors[field_name]["__ERRORS"] = {self.name: "failed"}

--- a/src/convtools/contrib/models/utils.py
+++ b/src/convtools/contrib/models/utils.py
@@ -2,16 +2,19 @@
 python 3.6 and 3.7+ """
 # flake8: noqa
 import sys
+from threading import RLock
+from typing import Dict, List, Tuple, Union
+
+from .base import BaseModel, CastOverrides
 
 
 PY_VERSION = sys.version_info[0:2]
 
+UnionCls = Union[int, str].__class__
+
 if PY_VERSION <= (3, 6):
 
-    from typing import Dict, List, Union
-
     GenericAlias = type(List[int])
-    UnionCls = Union.__class__
 
     def is_generic_alias(obj):
         return isinstance(obj, GenericAlias) or is_generic_union_alias(obj)
@@ -22,11 +25,14 @@ if PY_VERSION <= (3, 6):
     def is_generic_list_alias(alias):
         return alias.__origin__ is List
 
+    def is_generic_tuple_alias(alias):
+        return alias.__origin__ is Tuple
+
     def is_generic_dict_alias(alias):
         return alias.__origin__ is Dict
 
 else:  # if PY_VERSION > (3, 6): -- comment for .coveragerc
-    from typing import Dict, List, Union, _GenericAlias  # type: ignore
+    from typing import _GenericAlias  # type: ignore
 
     def is_generic_alias(obj):
         return isinstance(obj, _GenericAlias)
@@ -36,6 +42,9 @@ else:  # if PY_VERSION > (3, 6): -- comment for .coveragerc
 
     def is_generic_list_alias(alias):
         return alias.__origin__ is list
+
+    def is_generic_tuple_alias(alias):
+        return alias.__origin__ is tuple
 
     def is_generic_dict_alias(alias):
         return alias.__origin__ is dict
@@ -51,3 +60,51 @@ def ensure_generic_alias_has_args(alias, type_var_to_type_value):
                 ),
             )
     return alias
+
+
+def is_model_cls(cls):
+    return isinstance(cls, type) and issubclass(cls, BaseModel)
+
+
+def __hash__(self):  # pylint: disable=invalid-name
+    return hash(tuple(self.__args__))
+
+
+patching_lock = RLock()
+
+
+class TypeValueWrapper:
+    """We have to patch typing.Union hash method to make it order sensitive as
+    it is required for lru_cache + Union type casting"""
+
+    __slots__ = ("type_value", "cast", "cast_overrides")
+
+    def __init__(self, type_value, cast: bool, cast_overrides: CastOverrides):
+        self.type_value = type_value
+        self.cast = cast
+        self.cast_overrides = cast_overrides
+
+    def validate_args(self):
+        if not self.cast and self.cast_overrides:
+            raise ValueError("remove cast_overrides when cast is not True")
+
+        if self.cast and is_model_cls(self.type_value):
+            raise ValueError(
+                "build(..., cast=True) doesn't affect inner models, either use field-level cast() or Meta.cast"
+            )
+
+    def __eq__(self, other):
+        return (
+            self.type_value == other.type_value
+            and self.cast == other.cast
+            and self.cast_overrides == other.cast_overrides
+        )
+
+    def __hash__(self):
+        with patching_lock:
+            prev_hash = UnionCls.__hash__
+            UnionCls.__hash__ = __hash__
+            try:
+                return hash(self.type_value)
+            finally:
+                UnionCls.__hash__ = prev_hash

--- a/src/convtools/contrib/models/validators/__init__.py
+++ b/src/convtools/contrib/models/validators/__init__.py
@@ -1,3 +1,3 @@
 """Exposes validators - objects which only check the data and populate error
 objects"""
-from .validators import Custom, Gt, Gte, Lt, Lte, Regex, Type
+from .validators import Custom, Decimal, Gt, Gte, Lt, Lte, Regex, Type

--- a/src/convtools/conversion.py
+++ b/src/convtools/conversion.py
@@ -22,6 +22,7 @@ from .base import (
     Dict,
     DictComp,
     DropWhile,
+    Eq,
     EscapedString,
     FilterConversion,
     GeneratorComp,
@@ -92,6 +93,7 @@ class Conversion:
     or_ = Or
     not_ = Not
     if_ = If
+    eq = Eq
 
     this = This
 

--- a/tests/test_convtools.py
+++ b/tests/test_convtools.py
@@ -5,12 +5,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from convtools import conversion as c
-from convtools.base import (
-    LazyEscapedString,
-    Namespace,
-    NamespaceCtx,
-    PipeConversion,
-)
+from convtools.base import LazyEscapedString, Namespace
 from convtools.utils import Code
 
 
@@ -289,6 +284,8 @@ def test_naive_conversion_item():
     assert (c.naive(5) % c.this).execute(2) == c(5).mod(c.this).execute(2) == 1
 
     assert c.this.eq(1).eq(1).execute(1) == (c.this == 1).execute(1)
+    assert c.this.eq(c.this == 2).execute(2) is False
+    assert c.eq(c.this, c.this * 1, 7).execute(7) is True
 
 
 def test_item():
@@ -422,6 +419,12 @@ def test_naive_conversion_or_and():
         == c.and_(c.this, 1, 2).or_(3).execute(1)
         == 2
     )
+
+    assert c.this.or_(c.or_(c.this, 3)).execute(0) == 3
+    assert (c.this | (c.this | 3)).execute(0) == 3
+
+    assert c.this.and_(c.and_(c.this, 3)).execute(1) == 3
+    assert (c.this & (c.this & 3)).execute(1) == 3
 
 
 def test_escaped_string_conversion():


### PR DESCRIPTION
Experimental - contrib.model:
+++++++++++++++++++++++++++++

- reworked errors, returned by ``build`` and ``build_or_raise`` to allow for
  automated errors processing (now it's clear where path ends and error info
  starts)
- now ``cast`` not only supports casters, but complex types too:
  ``cast(t.List[t.Tuple[int]])``
- now it's possible to force all-field casting on a model level via ``Meta.cast
  = True`` class field
- ``build`` and ``build_or_raise`` can also force children casting via
  ``cast=True`` parameter (doesn't affect inner models as they have their own
  controls)
- now casting supports type-to-caster(s) overrides like:
  ``cast(overrides={date: casters.DateFromStr("%m/%d/%Y")})``,
  ``Meta.cast_overrides`` and ``build(..., cast_overrides={date: [...]})``
- added ``validators.Decimal(max_digits, decimal_places)``
- extended str caster to decode bytes and supported custom encodings like
  ``casters.Str("utf-16")``
- added quantization support to ``casters.DecimalLossy(quantize_exp, rounding)``
- added ``typing.Tuple`` support (both validation and casting)

Misc:
+++++

- updated `c.or_` and `c.and_` to better flatten nested constructions
